### PR TITLE
Automatically add dependencies for legacy modules

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,29 @@
+<?php
+
+$date = date('Y');
+
+$header = <<<EOF
+This file is part of Contao.
+
+Copyright (c) 2005-$date Leo Feyer
+
+@license LGPL-3.0+
+EOF;
+
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude('Fixtures')
+    ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers([
+        '-psr0',
+        'header_comment',
+        'short_array_syntax',
+        '-empty_return',
+    ])
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ sudo: false
 env:
   global:
     - COMPOSER_ALLOW_XDEBUG=0
-    - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "symfony/http-kernel": "~2.8|~3.0",
-        "symfony/filesystem": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
-        "symfony/config": "~2.8|~3.0",
-        "symfony/routing": "~2.8|~3.0"
+        "symfony/http-kernel": "^2.8|^3.0",
+        "symfony/filesystem": "^2.8|^3.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/config": "^2.8|^3.0",
+        "symfony/routing": "^2.8|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "satooshi/php-coveralls": "~1.0",
+        "phpunit/phpunit": "^4.5",
+        "satooshi/php-coveralls": "^1.0",
         "contao/core-bundle": "^4.3.3"
     },
     "autoload": {
@@ -29,7 +29,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Contao\\ManagerPlugin\\Test\\": "tests/"
+            "Contao\\ManagerPlugin\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "satooshi/php-coveralls": "~1.0",
-        "contao/core-bundle": "~4.2"
+        "contao/core-bundle": "^4.3.3"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.2.x-dev"
+            "dev-develop": "2.1.x-dev"
         }
     }
 }

--- a/src/Bundle/BundleLoader.php
+++ b/src/Bundle/BundleLoader.php
@@ -45,7 +45,7 @@ class BundleLoader
     private $filesystem;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param PluginLoader          $pluginLoader
      * @param ConfigResolverFactory $resolverFactory
@@ -69,7 +69,7 @@ class BundleLoader
     }
 
     /**
-     * Returns an ordered bundle map
+     * Returns an ordered bundle map.
      *
      * @param bool        $development
      * @param string|null $cacheFile
@@ -86,7 +86,7 @@ class BundleLoader
     }
 
     /**
-     * Loads the bundle cache
+     * Loads the bundle cache.
      *
      * @param bool        $development
      * @param string|null $cacheFile
@@ -105,7 +105,7 @@ class BundleLoader
     }
 
     /**
-     * Generates the bundles map
+     * Generates the bundles map.
      *
      * @param bool        $development
      * @param string|null $cacheFile

--- a/src/Bundle/Config/BundleConfig.php
+++ b/src/Bundle/Config/BundleConfig.php
@@ -13,7 +13,7 @@ namespace Contao\ManagerPlugin\Bundle\Config;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Provides methods to access the configuration
+ * Provides methods to access the configuration.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
@@ -100,7 +100,7 @@ class BundleConfig implements ConfigInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function loadInProduction()
     {
@@ -108,7 +108,7 @@ class BundleConfig implements ConfigInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLoadInProduction($loadInProduction)
     {
@@ -118,7 +118,7 @@ class BundleConfig implements ConfigInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function loadInDevelopment()
     {
@@ -126,7 +126,7 @@ class BundleConfig implements ConfigInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLoadInDevelopment($loadInDevelopment)
     {
@@ -136,11 +136,11 @@ class BundleConfig implements ConfigInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getBundleInstance(KernelInterface $kernel)
     {
-        return new $this->name;
+        return new $this->name();
     }
 
     /**

--- a/src/Bundle/Config/ConfigInterface.php
+++ b/src/Bundle/Config/ConfigInterface.php
@@ -14,28 +14,28 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Autoload configuration interface
+ * Autoload configuration interface.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
 interface ConfigInterface
 {
     /**
-     * Returns the name
+     * Returns the name.
      *
      * @return string
      */
     public function getName();
 
     /**
-     * Returns the replaces
+     * Returns the replaces.
      *
      * @return array
      */
     public function getReplace();
 
     /**
-     * Sets the replaces
+     * Sets the replaces.
      *
      * @param array $replace
      *
@@ -44,14 +44,14 @@ interface ConfigInterface
     public function setReplace(array $replace);
 
     /**
-     * Returns the "load after" bundles
+     * Returns the "load after" bundles.
      *
      * @return array
      */
     public function getLoadAfter();
 
     /**
-     * Sets the "load after" bundles
+     * Sets the "load after" bundles.
      *
      * @param array $loadAfter
      *
@@ -60,14 +60,14 @@ interface ConfigInterface
     public function setLoadAfter(array $loadAfter);
 
     /**
-     * Returns if the bundle should be loaded in "prod" environment
+     * Returns if the bundle should be loaded in "prod" environment.
      *
      * @return bool
      */
     public function loadInProduction();
 
     /**
-     * Sets if bundle should be loaded in "prod" environment
+     * Sets if bundle should be loaded in "prod" environment.
      *
      * @param bool $loadInDevelopment
      *
@@ -76,14 +76,14 @@ interface ConfigInterface
     public function setLoadInProduction($loadInProduction);
 
     /**
-     * Returns if the bundle should be loaded in "dev" environment
+     * Returns if the bundle should be loaded in "dev" environment.
      *
      * @return bool
      */
     public function loadInDevelopment();
 
     /**
-     * Sets if bundle should be loaded in "dev" environment
+     * Sets if bundle should be loaded in "dev" environment.
      *
      * @param bool $loadInDevelopment
      *

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -13,7 +13,7 @@ namespace Contao\ManagerPlugin\Bundle\Config;
 use Contao\ManagerPlugin\Dependency\DependencyResolverTrait;
 
 /**
- * Resolves the bundles map from the configuration objects
+ * Resolves the bundles map from the configuration objects.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
@@ -27,7 +27,7 @@ class ConfigResolver implements ConfigResolverInterface
     protected $configs = [];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function add(ConfigInterface $config)
     {
@@ -37,7 +37,7 @@ class ConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getBundleConfigs($development)
     {
@@ -50,16 +50,16 @@ class ConfigResolver implements ConfigResolverInterface
             }
         }
 
-        $loadingOrder    = $this->buildLoadingOrder();
-        $replaces        = $this->buildReplaceMap();
+        $loadingOrder = $this->buildLoadingOrder();
+        $replaces = $this->buildReplaceMap();
         $normalizedOrder = $this->normalizeLoadingOrder($loadingOrder, $replaces);
-        $resolvedOrder   = $this->orderByDependencies($normalizedOrder);
+        $resolvedOrder = $this->orderByDependencies($normalizedOrder);
 
         return $this->order($bundles, $resolvedOrder);
     }
 
     /**
-     * Builds the replaces from the configuration objects
+     * Builds the replaces from the configuration objects.
      *
      * @return array
      */
@@ -79,7 +79,7 @@ class ConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * Builds the loading order from the configuration objects
+     * Builds the loading order from the configuration objects.
      *
      * @return array
      */
@@ -88,7 +88,7 @@ class ConfigResolver implements ConfigResolverInterface
         // Make sure the core bundle comes first
         // TODO is this still correct?
         $loadingOrder = [
-            'ContaoCoreBundle' => []
+            'ContaoCoreBundle' => [],
         ];
 
         foreach ($this->configs as $bundle) {
@@ -105,7 +105,7 @@ class ConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * Orders the bundles in a given order
+     * Orders the bundles in a given order.
      *
      * @param array $bundles
      * @param array $ordered
@@ -114,7 +114,7 @@ class ConfigResolver implements ConfigResolverInterface
      */
     private function order(array $bundles, array $ordered)
     {
-        $return  = [];
+        $return = [];
 
         foreach ($ordered as $package) {
             if (array_key_exists($package, $bundles)) {
@@ -126,7 +126,7 @@ class ConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * Normalizes the loading order array
+     * Normalizes the loading order array.
      *
      * @param array $loadingOrder
      * @param array $replace
@@ -147,7 +147,7 @@ class ConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * Replaces the legacy bundle names with their new name
+     * Replaces the legacy bundle names with their new name.
      *
      * @param array $loadAfter
      * @param array $replace

--- a/src/Bundle/Config/ConfigResolverFactory.php
+++ b/src/Bundle/Config/ConfigResolverFactory.php
@@ -11,7 +11,7 @@
 namespace Contao\ManagerPlugin\Bundle\Config;
 
 /**
- * Factory for ConfigResolverInterface
+ * Factory for ConfigResolverInterface.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  */

--- a/src/Bundle/Config/ConfigResolverInterface.php
+++ b/src/Bundle/Config/ConfigResolverInterface.php
@@ -17,7 +17,6 @@ use Contao\ManagerPlugin\Dependency\UnresolvableDependenciesException;
  */
 interface ConfigResolverInterface
 {
-
     /**
      * Adds a configuration object.
      *

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -25,7 +25,7 @@ class ModuleConfig extends BundleConfig
         'faq',
         'listing',
         'news',
-        'newsletter'
+        'newsletter',
     ];
 
     public function __construct($name)
@@ -36,7 +36,7 @@ class ModuleConfig extends BundleConfig
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      *
      * @throws \LogicException
      */

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class ModuleConfig extends BundleConfig
 {
     /**
-     * Old module names
      * @var array
      */
     private static $legacy = [
@@ -32,6 +31,11 @@ class ModuleConfig extends BundleConfig
         'newsletter',
     ];
 
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     */
     public function __construct($name)
     {
         parent::__construct($name);
@@ -49,6 +53,9 @@ class ModuleConfig extends BundleConfig
         return new ContaoModuleBundle($this->name, $kernel->getRootDir());
     }
 
+    /**
+     * Adjust the configuraton so the module is loaded after the legacy modules.
+     */
     private function setLoadAfterLegacyModules()
     {
         $modules = array_merge(self::$legacy, [$this->getName()]);

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -18,7 +18,11 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class ModuleConfig extends BundleConfig
 {
-    const LEGACY_MODULES = [
+    /**
+     * Old module names
+     * @var array
+     */
+    private static $legacy = [
         'core',
         'calendar',
         'comments',
@@ -47,7 +51,7 @@ class ModuleConfig extends BundleConfig
 
     private function setLoadAfterLegacyModules()
     {
-        $modules = array_merge(self::LEGACY_MODULES, [$this->getName()]);
+        $modules = array_merge(self::$legacy, [$this->getName()]);
         sort($modules);
         $modules = array_values($modules);
         array_splice($modules, array_search($this->getName(), $modules, true));

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -52,6 +52,10 @@ class ModuleConfig extends BundleConfig
         $modules = array_values($modules);
         array_splice($modules, array_search($this->getName(), $modules, true));
 
+        if (!in_array('core', $modules, true)) {
+            $modules[] = 'core';
+        }
+
         $this->setLoadAfter($modules);
     }
 }

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -18,6 +18,23 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class ModuleConfig extends BundleConfig
 {
+    const LEGACY_MODULES = [
+        'core',
+        'calendar',
+        'comments',
+        'faq',
+        'listing',
+        'news',
+        'newsletter'
+    ];
+
+    public function __construct($name)
+    {
+        parent::__construct($name);
+
+        $this->setLoadAfterLegacyModules();
+    }
+
     /**
      * @inheritdoc
      *
@@ -26,5 +43,15 @@ class ModuleConfig extends BundleConfig
     public function getBundleInstance(KernelInterface $kernel)
     {
         return new ContaoModuleBundle($this->name, $kernel->getRootDir());
+    }
+
+    private function setLoadAfterLegacyModules()
+    {
+        $modules = array_merge(self::LEGACY_MODULES, [$this->getName()]);
+        sort($modules);
+        $modules = array_values($modules);
+        array_splice($modules, array_search($this->getName(), $modules, true));
+
+        $this->setLoadAfter($modules);
     }
 }

--- a/src/Bundle/Parser/DelegatingParser.php
+++ b/src/Bundle/Parser/DelegatingParser.php
@@ -47,7 +47,7 @@ class DelegatingParser implements ParserInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function supports($resource, $type = null)
     {

--- a/src/Bundle/Parser/IniParser.php
+++ b/src/Bundle/Parser/IniParser.php
@@ -13,7 +13,7 @@ namespace Contao\ManagerPlugin\Bundle\Parser;
 use Contao\ManagerPlugin\Bundle\Config\ModuleConfig;
 
 /**
- * Converts an INI configuration file into a ConfigInterface instance
+ * Converts an INI configuration file into a ConfigInterface instance.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
@@ -51,7 +51,7 @@ class IniParser implements ParserInterface
 
         $this->loaded[$resource] = true;
 
-        $path = $this->modulesDir . '/' . $resource . '/config/autoload.ini';
+        $path = $this->modulesDir.'/'.$resource.'/config/autoload.ini';
 
         if (file_exists($path)) {
             $requires = $this->parseIniFile($path);
@@ -63,7 +63,7 @@ class IniParser implements ParserInterface
                         $module = substr($module, 1);
 
                         // Do not add optional modules that are not installed, ContaoModuleBundle would throw exception
-                        if (!is_dir($this->modulesDir . '/' . $module)) {
+                        if (!is_dir($this->modulesDir.'/'.$module)) {
                             continue;
                         }
                     }
@@ -83,15 +83,15 @@ class IniParser implements ParserInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function supports($resource, $type = null)
     {
-        return 'ini' === $type || is_dir($this->modulesDir . '/' . (string) $resource);
+        return 'ini' === $type || is_dir($this->modulesDir.'/'.(string) $resource);
     }
 
     /**
-     * Parses the file and returns the configuration array
+     * Parses the file and returns the configuration array.
      *
      * @param string $file The file path
      *

--- a/src/Bundle/Parser/JsonParser.php
+++ b/src/Bundle/Parser/JsonParser.php
@@ -13,7 +13,7 @@ namespace Contao\ManagerPlugin\Bundle\Parser;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 
 /**
- * Converts a JSON configuration file into a configuration array
+ * Converts a JSON configuration file into a configuration array.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
@@ -34,7 +34,7 @@ class JsonParser implements ParserInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function supports($resource, $type = null)
     {
@@ -42,7 +42,7 @@ class JsonParser implements ParserInterface
     }
 
     /**
-     * Parses the file and returns the configuration array
+     * Parses the file and returns the configuration array.
      *
      * @param string $file The absolute file path
      *

--- a/src/Bundle/Parser/ParserInterface.php
+++ b/src/Bundle/Parser/ParserInterface.php
@@ -13,7 +13,7 @@ namespace Contao\ManagerPlugin\Bundle\Parser;
 use Contao\ManagerPlugin\Bundle\Config\ConfigInterface;
 
 /**
- * Configuration parser interface
+ * Configuration parser interface.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>

--- a/src/Dependency/DependencyResolverTrait.php
+++ b/src/Dependency/DependencyResolverTrait.php
@@ -22,11 +22,12 @@ trait DependencyResolverTrait
      * @param array $dependencies
      *
      * @return array
+     *
      * @throws UnresolvableDependenciesException
      */
     protected function orderByDependencies(array $dependencies)
     {
-        $ordered   = [];
+        $ordered = [];
         $available = array_keys($dependencies);
 
         while (0 !== count($dependencies)) {
@@ -34,7 +35,7 @@ trait DependencyResolverTrait
 
             if (false === $success) {
                 throw new UnresolvableDependenciesException(
-                    "The dependencies order could not be resolved.\n" . print_r($dependencies, true)
+                    "The dependencies order could not be resolved.\n".print_r($dependencies, true)
                 );
             }
         }
@@ -43,7 +44,7 @@ trait DependencyResolverTrait
     }
 
     /**
-     * Resolve the dependency order
+     * Resolve the dependency order.
      *
      * @param array $dependencies
      * @param array $ordered
@@ -57,7 +58,7 @@ trait DependencyResolverTrait
 
         foreach ($dependencies as $name => $requires) {
             if (true === $this->canBeResolved($requires, $available, $ordered)) {
-                $failed    = false;
+                $failed = false;
                 $ordered[] = $name;
 
                 unset($dependencies[$name]);
@@ -68,7 +69,7 @@ trait DependencyResolverTrait
     }
 
     /**
-     * Checks whether the requirements can be resolved
+     * Checks whether the requirements can be resolved.
      *
      * @param array $requires
      * @param array $available
@@ -82,6 +83,6 @@ trait DependencyResolverTrait
             return true;
         }
 
-        return (0 === count(array_diff(array_intersect($requires, $available), $ordered)));
+        return 0 === count(array_diff(array_intersect($requires, $available), $ordered));
     }
 }

--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -15,7 +15,7 @@ use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
 use Contao\ManagerPlugin\Dependency\UnresolvableDependenciesException;
 
 /**
- * Finds Contao manager plugins from Composer's installed.json
+ * Finds Contao manager plugins from Composer's installed.json.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  */
@@ -80,7 +80,7 @@ class PluginLoader
     }
 
     /**
-     * Loads plugins from Composer's installed.json
+     * Loads plugins from Composer's installed.json.
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException

--- a/src/Routing/RoutingPluginInterface.php
+++ b/src/Routing/RoutingPluginInterface.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
 /**
  * This file is part of Contao.
  *

--- a/tests/Bundle/BundleLoaderTest.php
+++ b/tests/Bundle/BundleLoaderTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle;
+namespace Contao\ManagerPlugin\Tests\Bundle;
 
 use Contao\ManagerPlugin\Bundle\BundleLoader;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
@@ -81,7 +81,7 @@ class BundleLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBundleConfigsDumpsToCacheFile()
     {
-        $cacheFile = sys_get_temp_dir() . '/' . uniqid('BundleLoader_', false);
+        $cacheFile = sys_get_temp_dir().'/'.uniqid('BundleLoader_', false);
         $configs = [new BundleConfig('foobar')];
 
         $this->assertFalse(file_exists($cacheFile));
@@ -111,25 +111,25 @@ class BundleLoaderTest extends \PHPUnit_Framework_TestCase
             'Test correctly calls development mode' => [
                 [$this->mockBundlePlugin([new BundleConfig('foobar')])],
                 1,
-                true
+                true,
             ],
             'Test correctly calls production mode' => [
                 [$this->mockBundlePlugin([new BundleConfig('foobar')])],
                 1,
-                false
+                false,
             ],
             'Test correctly adds multiple configs from a plugin' => [
                 [$this->mockBundlePlugin([new BundleConfig('foo'), new BundleConfig('bar')])],
                 2,
-                true
+                true,
             ],
             'Test correctly adds config from multiple plugins' => [
                 [
                     $this->mockBundlePlugin([new BundleConfig('foo')]),
-                    $this->mockBundlePlugin([new BundleConfig('bar')])
+                    $this->mockBundlePlugin([new BundleConfig('bar')]),
                 ],
                 2,
-                false
+                false,
             ],
             'Test ignores plugin without bundles' => [
                 [
@@ -138,7 +138,7 @@ class BundleLoaderTest extends \PHPUnit_Framework_TestCase
                     $this->mockBundlePlugin(),
                 ],
                 2,
-                false
+                false,
             ],
         ];
     }

--- a/tests/Bundle/Config/ConfigResolverFactoryTest.php
+++ b/tests/Bundle/Config/ConfigResolverFactoryTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Config;
+namespace Contao\ManagerPlugin\Tests\Bundle\Config;
 
 use Contao\ManagerPlugin\Bundle\Config\ConfigResolverFactory;
 use Contao\ManagerPlugin\Bundle\Config\ConfigResolverInterface;

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Config;
+namespace Contao\ManagerPlugin\Tests\Bundle\Config;
 
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Config\ConfigResolver;
@@ -21,7 +21,7 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
     private $resolver;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -100,7 +100,7 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
                 ],
                 [
                     'name1' => $config1,
-                ]
+                ],
             ],
             'Test load after order' => [
                 [
@@ -109,8 +109,8 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
                 ],
                 [
                     'name1' => $config1,
-                    'name2' => $config2
-                ]
+                    'name2' => $config2,
+                ],
             ],
             'Test replaces' => [
                 [
@@ -119,8 +119,8 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
                     $config3,
                 ],
                 [
-                    'name3' => $config3
-                ]
+                    'name3' => $config3,
+                ],
             ],
             'Test load after a module that does not exist but is replaced by new one' => [
                 [
@@ -129,8 +129,8 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
                 ],
                 [
                     'name5' => $config5,
-                    'name4' => $config4
-                ]
+                    'name4' => $config4,
+                ],
             ],
         ];
     }

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
 /**
  * This file is part of Contao.
  *
@@ -8,7 +16,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Config;
+namespace Contao\ManagerPlugin\Tests\Bundle\Config;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
@@ -116,7 +124,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $kernel = $this->getMock(KernelInterface::class);
         $kernel
             ->method('getRootDir')
-            ->willReturn(__DIR__ . self::FIXTURES_DIR . '/app')
+            ->willReturn(__DIR__.self::FIXTURES_DIR.'/app')
         ;
 
         $config = ModuleConfig::create('foobar');
@@ -125,7 +133,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(ContaoModuleBundle::class, $bundle);
         $this->assertEquals(
-            __DIR__ . self::FIXTURES_DIR . '/system/modules/foobar',
+            __DIR__.self::FIXTURES_DIR.'/system/modules/foobar',
             $bundle->getPath()
         );
     }
@@ -138,7 +146,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $kernel = $this->getMock(KernelInterface::class);
         $kernel
             ->method('getRootDir')
-            ->willReturn(__DIR__ . self::FIXTURES_DIR . '/app')
+            ->willReturn(__DIR__.self::FIXTURES_DIR.'/app')
         ;
 
         $config = ModuleConfig::create('barfoo');

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -145,4 +145,20 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $config->getBundleInstance($kernel);
     }
+
+    public function testModuelConfigLoadsAfterLegacyModules()
+    {
+        $config = ModuleConfig::create('foobar');
+        $this->assertContains('core', $config->getLoadAfter());
+        $this->assertNotContains('foobar', $config->getLoadAfter());
+        $this->assertNotContains('news', $config->getLoadAfter());
+
+        $config = ModuleConfig::create('a_module');
+        $this->assertContains('core', $config->getLoadAfter());
+        $this->assertNotContains('calendar', $config->getLoadAfter());
+
+        $config = ModuleConfig::create('z_custom');
+        $this->assertContains('core', $config->getLoadAfter());
+        $this->assertContains('news', $config->getLoadAfter());
+    }
 }

--- a/tests/Bundle/Parser/DelegatingParserTest.php
+++ b/tests/Bundle/Parser/DelegatingParserTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Parser;
+namespace Contao\ManagerPlugin\Tests\Bundle\Parser;
 
 use Contao\ManagerPlugin\Bundle\Parser\DelegatingParser;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
@@ -21,7 +21,7 @@ class DelegatingParserTest extends \PHPUnit_Framework_TestCase
     private $parser;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp()
     {

--- a/tests/Bundle/Parser/IniParserTest.php
+++ b/tests/Bundle/Parser/IniParserTest.php
@@ -68,7 +68,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('without-ini', $configs[0]->getName());
         $this->assertEquals([], $configs[0]->getReplace());
-        $this->assertEquals([], $configs[0]->getLoadAfter());
+        $this->assertNotEmpty($configs[0]->getLoadAfter());
         $this->assertTrue($configs[0]->loadInProduction());
         $this->assertTrue($configs[0]->loadInDevelopment());
     }
@@ -83,7 +83,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('without-requires', $configs[0]->getName());
         $this->assertEquals([], $configs[0]->getReplace());
-        $this->assertEquals([], $configs[0]->getLoadAfter());
+        $this->assertNotEmpty($configs[0]->getLoadAfter());
         $this->assertTrue($configs[0]->loadInProduction());
         $this->assertTrue($configs[0]->loadInDevelopment());
     }
@@ -98,7 +98,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foobar', $configs[0]->getName());
         $this->assertEquals([], $configs[0]->getReplace());
-        $this->assertEquals([], $configs[0]->getLoadAfter());
+        $this->assertNotEmpty($configs[0]->getLoadAfter());
         $this->assertTrue($configs[0]->loadInProduction());
         $this->assertTrue($configs[0]->loadInDevelopment());
     }

--- a/tests/Bundle/Parser/IniParserTest.php
+++ b/tests/Bundle/Parser/IniParserTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Parser;
+namespace Contao\ManagerPlugin\Tests\Bundle\Parser;
 
 use Contao\ManagerPlugin\Bundle\Config\ConfigInterface;
 use Contao\ManagerPlugin\Bundle\Parser\IniParser;
@@ -21,13 +21,13 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
     private $parser;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp()
     {
         parent::setUp();
 
-        $this->parser = new IniParser(__DIR__ . '/../../Fixtures/Bundle/IniParser');
+        $this->parser = new IniParser(__DIR__.'/../../Fixtures/Bundle/IniParser');
     }
 
     public function testInstantiation()
@@ -123,7 +123,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseBrokenIni()
     {
-        /**
+        /*
          * refs php - test the return value of a method that triggers an error with PHPUnit - Stack Overflow
          * http://stackoverflow.com/questions/1225776/test-the-return-value-of-a-method-that-triggers-an-error-with-phpunit
          */

--- a/tests/Bundle/Parser/JsonParserTest.php
+++ b/tests/Bundle/Parser/JsonParserTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\ManagerPlugin\Test\Bundle\Parser;
+namespace Contao\ManagerPlugin\Tests\Bundle\Parser;
 
 use Contao\ManagerPlugin\Bundle\Config\ConfigInterface;
 use Contao\ManagerPlugin\Bundle\Parser\JsonParser;
@@ -24,7 +24,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
     private $parser;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -49,7 +49,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
 
     public function testParseSimpleObject()
     {
-        $configs = $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/simple-object.json');
+        $configs = $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/simple-object.json');
 
         $this->assertCount(1, $configs);
 
@@ -66,7 +66,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
 
     public function testParseSimpleString()
     {
-        $configs = $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/simple-string.json');
+        $configs = $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/simple-string.json');
 
         $this->assertCount(1, $configs);
 
@@ -84,7 +84,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
     public function testParseDevelopmentAndProduction()
     {
         /** @var ConfigInterface[] $configs */
-        $configs = $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/dev-prod.json');
+        $configs = $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/dev-prod.json');
 
         $this->assertCount(3, $configs);
 
@@ -104,7 +104,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
     public function testParseOptional()
     {
         /** @var ConfigInterface[] $configs */
-        $configs = $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/optional.json');
+        $configs = $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/optional.json');
 
         $this->assertCount(2, $configs);
 
@@ -121,7 +121,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseNoBundle()
     {
-        $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/no-bundle.json');
+        $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/no-bundle.json');
     }
 
     /**
@@ -129,7 +129,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseMissingFile()
     {
-        $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/missing.json');
+        $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/missing.json');
     }
 
     /**
@@ -137,7 +137,7 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseInvalidJson()
     {
-        $this->parser->parse(__DIR__ . self::FIXTURES_DIR . '/invalid.json');
+        $this->parser->parse(__DIR__.self::FIXTURES_DIR.'/invalid.json');
     }
 
     /**

--- a/tests/PluginLoaderTest.php
+++ b/tests/PluginLoaderTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
 namespace Contao\ManagerPlugin\Test;
 
 use Contao\ManagerPlugin\PluginLoader;
@@ -20,9 +28,9 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadsPlugin()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooBarPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooBarPlugin.php';
 
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/installed.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/installed.json');
 
         $plugins = $pluginLoader->getInstances();
 
@@ -38,7 +46,7 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadFailsWhenPluginDoesNotExist()
     {
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/not-installed.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/not-installed.json');
 
         $pluginLoader->getInstances();
     }
@@ -48,10 +56,10 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetInstancesOfChecksInterface()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooBarPlugin.php';
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooConfigPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooBarPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooConfigPlugin.php';
 
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/mixed.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/mixed.json');
 
         $plugins = $pluginLoader->getInstancesOf(PluginLoader::CONFIG_PLUGINS);
 
@@ -66,9 +74,9 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadsGlobalManagerPlugin()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/ContaoManagerPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/ContaoManagerPlugin.php';
 
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/empty.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/empty.json');
 
         $plugins = $pluginLoader->getInstances();
 
@@ -82,10 +90,10 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadsManagerBundlePluginFirst()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooBarPlugin.php';
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooConfigPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooBarPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooConfigPlugin.php';
 
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/manager-bundle.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/manager-bundle.json');
 
         $plugins = $pluginLoader->getInstances();
 
@@ -100,10 +108,10 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadOrdersPluginByDependencies()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooBarPlugin.php';
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooDependendPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooBarPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooDependendPlugin.php';
 
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/dependencies.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/dependencies.json');
 
         $plugins = $pluginLoader->getInstances();
 
@@ -118,12 +126,12 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadIsOnlyRunOnce()
     {
-        include_once __DIR__ . '/' . self::FIXTURES_DIR . '/FooBarPlugin.php';
+        include_once __DIR__.'/'.self::FIXTURES_DIR.'/FooBarPlugin.php';
 
         /** @var PluginLoader|\PHPUnit_Framework_MockObject_MockObject $pluginLoader */
         $pluginLoader = $this->getMockBuilder(PluginLoader::class)
             ->setMethods(['orderPlugins'])
-            ->setConstructorArgs([__DIR__ . '/' . self::FIXTURES_DIR . '/installed.json'])
+            ->setConstructorArgs([__DIR__.'/'.self::FIXTURES_DIR.'/installed.json'])
             ->getMock()
         ;
 
@@ -143,7 +151,7 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadMissingFile()
     {
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/missing.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/missing.json');
 
         $pluginLoader->getInstances();
     }
@@ -153,7 +161,7 @@ class PluginLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadInvalidJson()
     {
-        $pluginLoader = new PluginLoader(__DIR__ . '/' . self::FIXTURES_DIR . '/invalid.json');
+        $pluginLoader = new PluginLoader(__DIR__.'/'.self::FIXTURES_DIR.'/invalid.json');
 
         $pluginLoader->getInstances();
     }


### PR DESCRIPTION
If a module in `system/modules` does currently not have an `autoload.ini`, the sorting of dependencies gets wrong because the original core modules no longer exist so the sort-by-name no longer applies.

This PR restores at least the functionality to request sorting before the legacy core modules. Having an `autoload.ini` would automatically override these defaults.

*Open question:*
If the legacy modules in `Contao\ModuleLoader` would be a constant instead of a private method, we would not have to re-define these again in the `ModuleConfig`. I suggest to make that change, it cannot be a BC break.