### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
-        "symfony/config": "^2.8|^3.0|^4.0",
-        "symfony/dependency-injection": "^2.8|^3.0|^4.0",
-        "symfony/filesystem": "^2.8|^3.0|^4.0",
-        "symfony/http-kernel": "^2.8|^3.0|^4.0",
-        "symfony/routing": "^2.8|^3.0|^4.0"
+        "php": "^5.6 || ^7.0",
+        "symfony/config": "^2.8 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0",
+        "symfony/filesystem": "^2.8 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0",
+        "symfony/routing": "^2.8 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "contao/core-bundle": "^4.3.3",


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).