### PR TITLE
Added ApiPluginInterface

### DIFF
--- a/src/Api/ApiPluginInterface.php
+++ b/src/Api/ApiPluginInterface.php
@@ -22,15 +22,6 @@ interface ApiPluginInterface
     public function getApiFeatures(): array;
 
     /**
-     * Allows to override features that are provided by the Contao Managed Edition.
-     *
-     * @param array $features
-     *
-     * @return array
-     */
-    public function overrideApiFeatures(array $features): array;
-
-    /**
      * Adds additional commands to the Manager API.
      *
      * @return array

--- a/src/Api/ApiPluginInterface.php
+++ b/src/Api/ApiPluginInterface.php
@@ -15,7 +15,7 @@ namespace Contao\ManagerPlugin\Api;
 interface ApiPluginInterface
 {
     /**
-     * Gets features this plugin can handle.
+     * Returns the features this plugin can handle.
      *
      * @return array
      */

--- a/src/Api/ApiPluginInterface.php
+++ b/src/Api/ApiPluginInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin\Api;
+
+interface ApiPluginInterface
+{
+    /**
+     * Gets features this plugin can handle.
+     *
+     * @return array
+     */
+    public function getApiFeatures(): array;
+
+    /**
+     * Allows to override features that are provided by the Contao Managed Edition.
+     *
+     * @param array $features
+     *
+     * @return array
+     */
+    public function overrideApiFeatures(array $features): array;
+
+    /**
+     * Adds additional commands to the Manager API.
+     *
+     * @return array
+     */
+    public function getApiCommands(): array;
+}


### PR DESCRIPTION
The `ApiPluginInterface` allows a plugin to extend the Contao Manager API.
 1. by providing commands
 2. by extending the features list

see https://github.com/contao/manager-bundle/pull/75 for the actual implementation