### PR TITLE
Optimize contao-provider imports

### DIFF
--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -19,6 +19,7 @@ use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Repository\ArtifactRepository;
 use Composer\Repository\RepositoryInterface;
+use Composer\Semver\Constraint\Constraint;
 
 class ArtifactsPlugin implements PluginInterface
 {
@@ -62,6 +63,13 @@ class ArtifactsPlugin implements PluginInterface
 
         foreach ($artifacts->getPackages() as $package) {
             if ('contao-provider' !== $package->getType() || !\array_key_exists($package->getName(), $requires)) {
+                continue;
+            }
+
+            $constraint = $requires[$package->getName()]->getConstraint();
+            $version = new Constraint(Constraint::OP_EQ, $package->getVersion());
+
+            if (null === $constraint || !$constraint->matches($version)) {
                 continue;
             }
 


### PR DESCRIPTION
The manager-plugin currently imports repositories from all ZIP artifacts that match type `contao-provider`. This is or can be problematic if a new version is installed, because the old one might still exist. This PR optimizes:

1. providers will only be imported if they match the `require` statement in the root `composer.json`. Contao Manager 1.2 will set the requirements to an absolute version (the one from the last file upload), so the constraint should only ever match one ZIP file.
2. Additionally, it will prevent multiple of the same repositories to be added. This can also happen if the same repo/credentials are required for multiple artifacts, e.g. when using Private Packagist.