### PR TITLE
Autoload the App namespace if none is configured

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "extra": {
         "class": [
             "Contao\\ManagerPlugin\\Composer\\ArtifactsPlugin",
-            "Contao\\ManagerPlugin\\Composer\\ManagerPluginInstaller"
+            "Contao\\ManagerPlugin\\Composer\\ManagerPluginInstaller",
+            "Contao\\ManagerPlugin\\Composer\\AppAutoloadPlugin"
         ]
     },
     "autoload": {

--- a/src/Composer/AppAutoloadPlugin.php
+++ b/src/Composer/AppAutoloadPlugin.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+class AppAutoloadPlugin implements PluginInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function activate(Composer $composer, IOInterface $io): void
+    {
+        $rootPackage = $composer->getPackage();
+
+        $autoload = $rootPackage->getAutoload();
+
+        if (empty($autoload)) {
+            $rootPackage->setAutoload(['psr-4' => ['App\\' => 'src/']]);
+        }
+    }
+}

--- a/tests/Composer/AppAutoloadPluginTest.php
+++ b/tests/Composer/AppAutoloadPluginTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin\Tests\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\RootPackageInterface;
+use Contao\ManagerPlugin\Composer\AppAutoloadPlugin;
+use PHPUnit\Framework\TestCase;
+
+class AppAutoloadPluginTest extends TestCase
+{
+    public function testAddsTheAppNamespaceIfNoneIsDefined()
+    {
+        $package = $this->createMock(RootPackageInterface::class);
+        $package
+            ->expects($this->once())
+            ->method('getAutoload')
+            ->willReturn([])
+        ;
+
+        $package
+            ->expects($this->once())
+            ->method('setAutoload')
+            ->with(['psr-4' => ['App\\' => 'src/']])
+        ;
+
+        $composer = $this->createMock(Composer::class);
+        $composer
+            ->expects($this->once())
+            ->method('getPackage')
+            ->willReturn($package)
+        ;
+
+        $io = $this->createMock(IOInterface::class);
+        $io
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        (new AppAutoloadPlugin())->activate($composer, $io);
+    }
+
+    public function testDoesNotAddTheAppNamespaceIfOneIsDefined()
+    {
+        $package = $this->createMock(RootPackageInterface::class);
+        $package
+            ->expects($this->once())
+            ->method('getAutoload')
+            ->willReturn(['psr-4' => ['AppBundle\\' => 'src/']])
+        ;
+
+        $package
+            ->expects($this->never())
+            ->method('setAutoload')
+        ;
+
+        $composer = $this->createMock(Composer::class);
+        $composer
+            ->expects($this->once())
+            ->method('getPackage')
+            ->willReturn($package)
+        ;
+
+        $io = $this->createMock(IOInterface::class);
+        $io
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        (new AppAutoloadPlugin())->activate($composer, $io);
+    }
+}


### PR DESCRIPTION
With this change, we can remove https://github.com/contao/managed-edition/blob/master/composer.json#L35-L39

We could even make this more universal and use the plugin to set the asset path etc, so the default composer.json gets even smaller 😎 