### PR TITLE
Added support for Composer API v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1 || ^2.0",
         "symfony/config": "^3.3 || ^4.0",
         "symfony/dependency-injection": "^3.3 || ^4.0",
         "symfony/filesystem": "^3.3 || ^4.0",
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "ext-zip": "*",
-        "composer/composer": "^1.1",
+        "composer/composer": "^1.1 || ^2.0",
         "contao/core-bundle": "^4.5",
         "friendsofphp/php-cs-fixer": "^2.14",
         "php-http/guzzle6-adapter": "^1.1",

--- a/src/Composer/AppAutoloadPlugin.php
+++ b/src/Composer/AppAutoloadPlugin.php
@@ -31,4 +31,14 @@ class AppAutoloadPlugin implements PluginInterface
             $rootPackage->setAutoload(['psr-4' => ['App\\' => 'src/']]);
         }
     }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here
+    }
 }

--- a/src/Composer/AppAutoloadPlugin.php
+++ b/src/Composer/AppAutoloadPlugin.php
@@ -32,12 +32,12 @@ class AppAutoloadPlugin implements PluginInterface
         }
     }
 
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here
     }
 
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here
     }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -42,12 +42,12 @@ class ArtifactsPlugin implements PluginInterface
         $this->registerProviders($repository, $composer);
     }
 
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here
     }
 
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here
     }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -42,6 +42,16 @@ class ArtifactsPlugin implements PluginInterface
         $this->registerProviders($repository, $composer);
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here
+    }
+
     private function addArtifactRepository(Composer $composer, string $repositoryUrl): ?RepositoryInterface
     {
         $repository = $composer->getRepositoryManager()->createRepository('artifact', ['url' => $repositoryUrl]);

--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -149,6 +149,16 @@ PHP;
         // Nothing to do here, as all features are provided through event listeners
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here, as all features are provided through event listeners
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Nothing to do here, as all features are provided through event listeners
+    }
+
     public function dumpPlugins(Event $event): void
     {
         $io = $event->getIO();

--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -149,12 +149,12 @@ PHP;
         // Nothing to do here, as all features are provided through event listeners
     }
 
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here, as all features are provided through event listeners
     }
 
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
         // Nothing to do here, as all features are provided through event listeners
     }

--- a/tests/Composer/AppAutoloadPluginTest.php
+++ b/tests/Composer/AppAutoloadPluginTest.php
@@ -81,7 +81,7 @@ class AppAutoloadPluginTest extends TestCase
         (new AppAutoloadPlugin())->activate($composer, $io);
     }
 
-    public function testImplementsTheAPI2Methods()
+    public function testImplementsTheAPI2Methods(): void
     {
         $plugin = new AppAutoloadPlugin();
         $composer = $this->createMock(Composer::class);

--- a/tests/Composer/AppAutoloadPluginTest.php
+++ b/tests/Composer/AppAutoloadPluginTest.php
@@ -80,4 +80,14 @@ class AppAutoloadPluginTest extends TestCase
 
         (new AppAutoloadPlugin())->activate($composer, $io);
     }
+
+    public function testImplementsTheAPI2Methods()
+    {
+        $plugin = new AppAutoloadPlugin();
+        $composer = $this->createMock(Composer::class);
+        $io = $this->createMock(IOInterface::class);
+
+        $this->assertNull($plugin->deactivate($composer, $io));
+        $this->assertNull($plugin->uninstall($composer, $io));
+    }
 }

--- a/tests/Composer/ArtifactsPluginTest.php
+++ b/tests/Composer/ArtifactsPluginTest.php
@@ -362,7 +362,7 @@ class ArtifactsPluginTest extends TestCase
         $plugin->activate($composer, $this->createMock(IOInterface::class));
     }
 
-    public function testImplementsTheAPI2Methods()
+    public function testImplementsTheAPI2Methods(): void
     {
         $plugin = new ArtifactsPlugin();
         $composer = $this->createMock(Composer::class);

--- a/tests/Composer/ArtifactsPluginTest.php
+++ b/tests/Composer/ArtifactsPluginTest.php
@@ -362,6 +362,16 @@ class ArtifactsPluginTest extends TestCase
         $plugin->activate($composer, $this->createMock(IOInterface::class));
     }
 
+    public function testImplementsTheAPI2Methods()
+    {
+        $plugin = new ArtifactsPlugin();
+        $composer = $this->createMock(Composer::class);
+        $io = $this->createMock(IOInterface::class);
+
+        $this->assertNull($plugin->deactivate($composer, $io));
+        $this->assertNull($plugin->uninstall($composer, $io));
+    }
+
     /**
      * @param Config&MockObject            $config
      * @param RepositoryManager&MockObject $repositoryManager

--- a/tests/Composer/ManagerPluginInstallerTest.php
+++ b/tests/Composer/ManagerPluginInstallerTest.php
@@ -390,7 +390,7 @@ class ManagerPluginInstallerTest extends TestCase
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
     }
 
-    public function testImplementsTheAPI2Methods()
+    public function testImplementsTheAPI2Methods(): void
     {
         $plugin = new ManagerPluginInstaller();
         $composer = $this->createMock(Composer::class);

--- a/tests/Composer/ManagerPluginInstallerTest.php
+++ b/tests/Composer/ManagerPluginInstallerTest.php
@@ -390,6 +390,16 @@ class ManagerPluginInstallerTest extends TestCase
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
     }
 
+    public function testImplementsTheAPI2Methods()
+    {
+        $plugin = new ManagerPluginInstaller();
+        $composer = $this->createMock(Composer::class);
+        $io = $this->createMock(IOInterface::class);
+
+        $this->assertNull($plugin->deactivate($composer, $io));
+        $this->assertNull($plugin->uninstall($composer, $io));
+    }
+
     /**
      * @return PackageInterface&MockObject
      */


### PR DESCRIPTION
To resolve the composer.json locally (and get composer v2)

- Add "composer/semver": "^2.0@dev"
- Remove friendsofphp/php-cs-fixer as it is no compatible with semver v2