### PR TITLE
Add compatibility with Symfony 5

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,0 @@
-# Contributors
-
- * Leo Feyer (leofeyer)
- * Andreas Schempp (aschempp)
- * Christian Schiffler (discordier)
- * Kamil Kuzminski (qzminski)
- * Jim Schmid (sheeep)

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "symfony/config": "^3.3 || ^4.0",
-        "symfony/dependency-injection": "^3.3 || ^4.0",
-        "symfony/filesystem": "^3.3 || ^4.0",
-        "symfony/http-kernel": "^3.3 || ^4.0",
-        "symfony/routing": "^3.3 || ^4.0"
+        "symfony/config": "^3.3 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^3.3 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^3.3 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^3.3 || ^4.0 || ^5.0",
+        "symfony/routing": "^3.3 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "ext-zip": "*",
@@ -26,6 +26,9 @@
         "php-http/guzzle6-adapter": "^1.1",
         "phpunit/phpunit": "^6.5",
         "symfony/phpunit-bridge": "^3.4.5"
+    },
+    "conflict": {
+        "contao/manager-bundle": "< 4.9.4"
     },
     "extra": {
         "class": [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "ext-zip": "*",
         "composer/composer": "^1.1 || ^2.0",
-        "contao/core-bundle": "^4.5",
+        "contao/core-bundle": "4.10.x-dev",
         "friendsofphp/php-cs-fixer": "^2.14",
         "php-http/guzzle6-adapter": "^1.1",
         "phpunit/phpunit": "^6.5",
@@ -34,7 +34,7 @@
             "Contao\\ManagerPlugin\\Composer\\AppAutoloadPlugin"
         ],
         "symfony": {
-            "require": "^3.3 || ^4.0"
+            "require": "^3.3 || ^4.0 || ^5.0"
         }
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
         "phpunit/phpunit": "^6.5",
         "symfony/phpunit-bridge": "^3.4.5"
     },
-    "conflict": {
-        "contao/manager-bundle": "< 4.9.4"
-    },
     "extra": {
         "class": [
             "Contao\\ManagerPlugin\\Composer\\ArtifactsPlugin",

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -29,7 +29,9 @@ class ModuleConfig extends BundleConfig
      */
     public function getBundleInstance(KernelInterface $kernel)
     {
-        return new ContaoModuleBundle($this->name, $kernel->getProjectDir());
+        $dir = \method_exists($kernel, 'getRootDir') ? $kernel->getRootDir() : $kernel->getProjectDir();
+
+        return new ContaoModuleBundle($this->name, $dir);
     }
 
     /**

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -29,7 +29,7 @@ class ModuleConfig extends BundleConfig
      */
     public function getBundleInstance(KernelInterface $kernel)
     {
-        return new ContaoModuleBundle($this->name, $kernel->getRootDir());
+        return new ContaoModuleBundle($this->name, $kernel->getProjectDir());
     }
 
     /**

--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -29,7 +29,7 @@ class ModuleConfig extends BundleConfig
      */
     public function getBundleInstance(KernelInterface $kernel)
     {
-        $dir = \method_exists($kernel, 'getRootDir') ? $kernel->getRootDir() : $kernel->getProjectDir();
+        $dir = method_exists($kernel, 'getRootDir') ? $kernel->getRootDir() : $kernel->getProjectDir();
 
         return new ContaoModuleBundle($this->name, $dir);
     }

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -110,7 +110,7 @@ class ConfigTest extends TestCase
         $bundle = $config->getBundleInstance($kernel);
 
         $this->assertInstanceOf(ContaoModuleBundle::class, $bundle);
-        $this->assertSame(__DIR__.'/../../Fixtures/Bundle/Config/system/modules/foobar', $bundle->getPath());
+        $this->assertSame(\dirname(__DIR__, 2).'/Fixtures/Bundle/Config/system/modules/foobar', $bundle->getPath());
     }
 
     public function testReturnsTheBundlePathWithRootDir(): void
@@ -121,7 +121,7 @@ class ConfigTest extends TestCase
         $bundle = $config->getBundleInstance($kernel);
 
         $this->assertInstanceOf(ContaoModuleBundle::class, $bundle);
-        $this->assertSame(__DIR__.'/../../Fixtures/Bundle/Config/system/modules/foobar', $bundle->getPath());
+        $this->assertSame(\dirname(__DIR__, 2).'/Fixtures/Bundle/Config/system/modules/foobar', $bundle->getPath());
     }
 
     public function testFailsToReturnTheBundleInstanceIfTheNameIsInvalid(): void

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Config\ConfigInterface;
 use Contao\ManagerPlugin\Bundle\Config\ModuleConfig;
-use PHPUnit\Framework\MockObject\Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -103,9 +102,20 @@ class ConfigTest extends TestCase
         $this->assertInstanceOf(ContaoCoreBundle::class, $bundle);
     }
 
-    public function testReturnsTheBundlePath(): void
+    public function testReturnsTheBundlePathWithProjectDir(): void
     {
         $kernel = $this->mockKernel(__DIR__.'/../../Fixtures/Bundle/Config');
+
+        $config = ModuleConfig::create('foobar');
+        $bundle = $config->getBundleInstance($kernel);
+
+        $this->assertInstanceOf(ContaoModuleBundle::class, $bundle);
+        $this->assertSame(__DIR__.'/../../Fixtures/Bundle/Config/system/modules/foobar', $bundle->getPath());
+    }
+
+    public function testReturnsTheBundlePathWithRootDir(): void
+    {
+        $kernel = $this->mockKernel(__DIR__.'/../../Fixtures/Bundle/Config/app');
 
         $config = ModuleConfig::create('foobar');
         $bundle = $config->getBundleInstance($kernel);
@@ -149,17 +159,10 @@ class ConfigTest extends TestCase
      */
     private function mockKernel(string $projectDir): KernelInterface
     {
-        $generator = new Generator();
-        $methods = $generator->getClassMethods(KernelInterface::class);
-        $methods[] = 'getProjectDir';
-
-        $kernel = $this->getMockBuilder(KernelInterface::class)
-            ->setMethods($methods)
-            ->getMock()
-        ;
+        $kernel = $this->createMock(KernelInterface::class);
 
         $kernel
-            ->method('getProjectDir')
+            ->method(method_exists($kernel, 'getRootDir') ? 'getRootDir' : 'getProjectDir')
             ->willReturn($projectDir)
         ;
 

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -17,6 +17,8 @@ use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Config\ConfigInterface;
 use Contao\ManagerPlugin\Bundle\Config\ModuleConfig;
+use PHPUnit\Framework\MockObject\Generator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -103,11 +105,7 @@ class ConfigTest extends TestCase
 
     public function testReturnsTheBundlePath(): void
     {
-        $kernel = $this->createMock(KernelInterface::class);
-        $kernel
-            ->method('getRootDir')
-            ->willReturn(__DIR__.'/../../Fixtures/Bundle/Config/app')
-        ;
+        $kernel = $this->mockKernel(__DIR__.'/../../Fixtures/Bundle/Config');
 
         $config = ModuleConfig::create('foobar');
         $bundle = $config->getBundleInstance($kernel);
@@ -118,11 +116,7 @@ class ConfigTest extends TestCase
 
     public function testFailsToReturnTheBundleInstanceIfTheNameIsInvalid(): void
     {
-        $kernel = $this->createMock(KernelInterface::class);
-        $kernel
-            ->method('getRootDir')
-            ->willReturn(__DIR__.'/../../Fixtures/Bundle/Config/app')
-        ;
+        $kernel = $this->mockKernel(__DIR__.'/../../Fixtures/Bundle/Config');
 
         $config = ModuleConfig::create('barfoo');
 
@@ -148,5 +142,27 @@ class ConfigTest extends TestCase
 
         $this->assertContains('core', $config->getLoadAfter());
         $this->assertContains('news', $config->getLoadAfter());
+    }
+
+    /**
+     * @return KernelInterface&MockObject
+     */
+    private function mockKernel(string $projectDir): KernelInterface
+    {
+        $generator = new Generator();
+        $methods = $generator->getClassMethods(KernelInterface::class);
+        $methods[] = 'getProjectDir';
+
+        $kernel = $this->getMockBuilder(KernelInterface::class)
+            ->setMethods($methods)
+            ->getMock()
+        ;
+
+        $kernel
+            ->method('getProjectDir')
+            ->willReturn($projectDir)
+        ;
+
+        return $kernel;
     }
 }

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -127,7 +127,6 @@ class ConfigTest extends TestCase
     public function testFailsToReturnTheBundleInstanceIfTheNameIsInvalid(): void
     {
         $kernel = $this->mockKernel(__DIR__.'/../../Fixtures/Bundle/Config');
-
         $config = ModuleConfig::create('barfoo');
 
         $this->expectException('LogicException');
@@ -160,7 +159,6 @@ class ConfigTest extends TestCase
     private function mockKernel(string $projectDir): KernelInterface
     {
         $kernel = $this->createMock(KernelInterface::class);
-
         $kernel
             ->method(method_exists($kernel, 'getRootDir') ? 'getRootDir' : 'getProjectDir')
             ->willReturn($projectDir)


### PR DESCRIPTION
~~This requires https://github.com/contao/contao/pull/1891 before the build passes. I assume https://github.com/contao/contao/pull/1891 will be merged into Contao 4.9.4, therefore the conflict rule in `composer.json`.~~

**Road to Symfony 5:** https://github.com/contao/contao/issues/1889