### PR TITLE
Fix issue that loading order permutates per system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/phpunit-bridge": "^3.4.5"
     },
     "conflict": {
-        "contao/manager-bundle": ">= 4.9.0 <4.9.4"
+        "contao/manager-bundle": "4.9.* <4.9.4"
     },
     "extra": {
         "class": [

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "phpunit/phpunit": "^6.5",
         "symfony/phpunit-bridge": "^3.4.5"
     },
+    "conflict": {
+        "contao/manager-bundle": ">= 4.9.0 <4.9.4"
+    },
     "extra": {
         "class": [
             "Contao\\ManagerPlugin\\Composer\\ArtifactsPlugin",

--- a/src/Bundle/Config/BundleConfig.php
+++ b/src/Bundle/Config/BundleConfig.php
@@ -84,6 +84,7 @@ class BundleConfig implements ConfigInterface
     public function setReplace(array $replace): self
     {
         $this->replace = $replace;
+        sort($this->replace);
 
         return $this;
     }
@@ -102,6 +103,7 @@ class BundleConfig implements ConfigInterface
     public function setLoadAfter(array $loadAfter): self
     {
         $this->loadAfter = $loadAfter;
+        sort($this->loadAfter);
 
         return $this;
     }

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -64,7 +64,6 @@ class ConfigResolver implements ConfigResolverInterface
     private function mergeConfig($otherConfig, ConfigInterface $config): ConfigInterface
     {
         if (!($otherConfig instanceof BundleConfig) || !($config instanceof BundleConfig)) {
-            // FIXME: can we handle type variance somehow? What about custom configs
             throw new UnexpectedValueException('Mixing config classes is not supported.');
         }
         // If both are bundle config, we have no problem and can merge.

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -91,7 +91,8 @@ class ConfigResolver implements ConfigResolverInterface
                 $loadingOrder[$name][] = $package;
             }
         }
-
+        ksort($loadingOrder);
+        
         return $loadingOrder;
     }
 

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -109,7 +109,9 @@ class ConfigResolver implements ConfigResolverInterface
                 $loadingOrder[$name][] = $package;
             }
         }
-        ksort($loadingOrder);
+        uksort($loadingOrder, function (string $a, string $b): int {
+            return md5($a) <=> md5($b);
+        });
 
         return $loadingOrder;
     }

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -47,6 +47,7 @@ class ConfigResolver implements ConfigResolverInterface
                 if (null !== $otherConfig = $bundles[$config->getName()] ?? null) {
                     $config = $this->mergeConfig($otherConfig, $config);
                 }
+
                 $bundles[$config->getName()] = $config;
             } else {
                 unset($bundles[$config->getName()]);
@@ -66,7 +67,8 @@ class ConfigResolver implements ConfigResolverInterface
         if (!($otherConfig instanceof BundleConfig) || !($config instanceof BundleConfig)) {
             throw new UnexpectedValueException('Mixing config classes is not supported.');
         }
-        // If both are bundle config, we have no problem and can merge.
+
+        // If both are bundle configs, we have no problem and can merge
         return BundleConfig::create($otherConfig->getName())
             ->setReplace(array_merge($otherConfig->getReplace(), $config->getReplace()))
             ->setLoadAfter(array_merge($otherConfig->getLoadAfter(), $config->getLoadAfter()))
@@ -109,9 +111,13 @@ class ConfigResolver implements ConfigResolverInterface
                 $loadingOrder[$name][] = $package;
             }
         }
-        uksort($loadingOrder, function (string $a, string $b): int {
-            return md5($a) <=> md5($b);
-        });
+
+        uksort(
+            $loadingOrder,
+            static function (string $a, string $b): int {
+                return md5($a) <=> md5($b);
+            }
+        );
 
         return $loadingOrder;
     }

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -72,7 +72,8 @@ class ConfigResolver implements ConfigResolverInterface
             ->setReplace(array_merge($otherConfig->getReplace(), $config->getReplace()))
             ->setLoadAfter(array_merge($otherConfig->getLoadAfter(), $config->getLoadAfter()))
             ->setLoadInProduction($otherConfig->loadInProduction() || $config->loadInProduction())
-            ->setLoadInDevelopment($otherConfig->loadInDevelopment() || $config->loadInDevelopment());
+            ->setLoadInDevelopment($otherConfig->loadInDevelopment() || $config->loadInDevelopment())
+        ;
     }
 
     /**

--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\ManagerPlugin\Bundle\Config;
 
 use Contao\ManagerPlugin\Dependency\DependencyResolverTrait;
+use UnexpectedValueException;
 
 class ConfigResolver implements ConfigResolverInterface
 {
@@ -43,6 +44,9 @@ class ConfigResolver implements ConfigResolverInterface
         // Only add bundles which match the environment
         foreach ($this->configs as $config) {
             if (($development && $config->loadInDevelopment()) || (!$development && $config->loadInProduction())) {
+                if (null !== $otherConfig = $bundles[$config->getName()] ?? null) {
+                    $config = $this->mergeConfig($otherConfig, $config);
+                }
                 $bundles[$config->getName()] = $config;
             } else {
                 unset($bundles[$config->getName()]);
@@ -55,6 +59,20 @@ class ConfigResolver implements ConfigResolverInterface
         $resolvedOrder = $this->orderByDependencies($normalizedOrder);
 
         return $this->order($bundles, $resolvedOrder);
+    }
+
+    private function mergeConfig($otherConfig, ConfigInterface $config): ConfigInterface
+    {
+        if (!($otherConfig instanceof BundleConfig) || !($config instanceof BundleConfig)) {
+            // FIXME: can we handle type variance somehow? What about custom configs
+            throw new UnexpectedValueException('Mixing config classes is not supported.');
+        }
+        // If both are bundle config, we have no problem and can merge.
+        return BundleConfig::create($otherConfig->getName())
+            ->setReplace(array_merge($otherConfig->getReplace(), $config->getReplace()))
+            ->setLoadAfter(array_merge($otherConfig->getLoadAfter(), $config->getLoadAfter()))
+            ->setLoadInProduction($otherConfig->loadInProduction() || $config->loadInProduction())
+            ->setLoadInDevelopment($otherConfig->loadInDevelopment() || $config->loadInDevelopment());
     }
 
     /**
@@ -92,7 +110,7 @@ class ConfigResolver implements ConfigResolverInterface
             }
         }
         ksort($loadingOrder);
-        
+
         return $loadingOrder;
     }
 

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -47,14 +47,10 @@ class ConfigResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider getBundleConfigs
+     * @dataProvider getBundleConfigsSeeded
      */
     public function testAddsTheBundleConfigs(array $configs, array $expectedResult): void
     {
-        // Shuffle the input around to ensure the input order does not alter the output.
-        // This does not guarantee failure if the random input already provides the expected output but is better
-        // than nothing - at least we have a higher probability than 0 to catch these issues here.
-        shuffle($configs);
         foreach ($configs as $config) {
             $this->resolver->add($config);
         }
@@ -69,6 +65,29 @@ class ConfigResolverTest extends TestCase
             $this->assertSame($config->loadInProduction(), $actualResult[$index]->loadInProduction());
             $this->assertSame($config->loadInDevelopment(), $actualResult[$index]->loadInDevelopment());
         }
+    }
+
+    /**
+     * @return array<string,BundleConfig[]|array<string,BundleConfig>>
+     */
+    public function getBundleConfigsSeeded(): array
+    {
+        $configs = $this->getBundleConfigs();
+        // Shuffle the input around to ensure the input order does not alter the output.
+        $output = [];
+        for ($seed = 0; $seed < 5; ++$seed) {
+            mt_srand($seed);
+            foreach ($configs as $explanation => $config) {
+                // Copy the input array.
+                $testData = \array_slice($config, 0);
+                shuffle($testData[0]);
+
+                $output['with mt_srand('.$seed.') '.$explanation] = $testData;
+            }
+        }
+        mt_srand();
+
+        return $output;
     }
 
     /**

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -61,7 +61,7 @@ class ConfigResolverTest extends TestCase
 
         $actualResult = $this->resolver->getBundleConfigs(false);
 
-        $this->assertCount(count($expectedResult), $actualResult);
+        $this->assertCount(\count($expectedResult), $actualResult);
         foreach ($expectedResult as $index => $config) {
             $this->assertSame($config->getName(), $actualResult[$index]->getName());
             $this->assertSame($config->getReplace(), $actualResult[$index]->getReplace());

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -61,7 +61,14 @@ class ConfigResolverTest extends TestCase
 
         $actualResult = $this->resolver->getBundleConfigs(false);
 
-        $this->assertEquals($expectedResult, $actualResult);
+        $this->assertCount(count($expectedResult), $actualResult);
+        foreach ($expectedResult as $index => $config) {
+            $this->assertSame($config->getName(), $actualResult[$index]->getName());
+            $this->assertSame($config->getReplace(), $actualResult[$index]->getReplace());
+            $this->assertSame($config->getLoadAfter(), $actualResult[$index]->getLoadAfter());
+            $this->assertSame($config->loadInProduction(), $actualResult[$index]->loadInProduction());
+            $this->assertSame($config->loadInDevelopment(), $actualResult[$index]->loadInDevelopment());
+        }
     }
 
     /**

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -58,6 +58,7 @@ class ConfigResolverTest extends TestCase
         $actualResult = $this->resolver->getBundleConfigs(false);
 
         $this->assertCount(\count($expectedResult), $actualResult);
+
         foreach ($expectedResult as $index => $config) {
             $this->assertSame($config->getName(), $actualResult[$index]->getName());
             $this->assertSame($config->getReplace(), $actualResult[$index]->getReplace());
@@ -73,18 +74,21 @@ class ConfigResolverTest extends TestCase
     public function getBundleConfigsSeeded(): array
     {
         $configs = $this->getBundleConfigs();
-        // Shuffle the input around to ensure the input order does not alter the output.
         $output = [];
+
+        // Shuffle the input around to ensure the input order does not alter the output
         for ($seed = 0; $seed < 5; ++$seed) {
             mt_srand($seed);
+
             foreach ($configs as $explanation => $config) {
-                // Copy the input array.
+                // Copy the input array
                 $testData = \array_slice($config, 0);
                 shuffle($testData[0]);
 
                 $output['with mt_srand('.$seed.') '.$explanation] = $testData;
             }
         }
+
         mt_srand();
 
         return $output;
@@ -105,6 +109,7 @@ class ConfigResolverTest extends TestCase
         $config7b = (new BundleConfig('name7'))->setReplace(['name2']);
         $config8a = (new BundleConfig('name8'))->setLoadAfter(['name1'])->setReplace(['foo']);
         $config8b = (new BundleConfig('name8'))->setLoadAfter(['name2'])->setReplace(['bar']);
+        $config8c = (new BundleConfig('name8'))->setLoadAfter(['name1', 'name2'])->setReplace(['foo', 'bar']);
 
         return [
             'Test default configs' => [
@@ -176,7 +181,7 @@ class ConfigResolverTest extends TestCase
                 [
                     'name1' => $config1,
                     'name2' => $config2,
-                    'name8' => (new BundleConfig('name8'))->setLoadAfter(['name1', 'name2'])->setReplace(['foo', 'bar']),
+                    'name8' => $config8c,
                 ],
             ],
         ];

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -54,7 +54,7 @@ class ConfigResolverTest extends TestCase
         // Shuffle the input around to ensure the input order does not alter the output.
         // This does not guarantee failure if the random input already provides the expected output but is better
         // than nothing - at least we have a higher probability than 0 to catch these issues here.
-         shuffle($configs);
+        shuffle($configs);
         foreach ($configs as $config) {
             $this->resolver->add($config);
         }

--- a/tests/Bundle/Config/ConfigTest.php
+++ b/tests/Bundle/Config/ConfigTest.php
@@ -51,9 +51,9 @@ class ConfigTest extends TestCase
 
         $this->assertEmpty($config->getReplace());
 
-        $config->setReplace(['foobar']);
+        $config->setReplace(['foobar', 'barfoo']);
 
-        $this->assertSame(['foobar'], $config->getReplace());
+        $this->assertSame(['barfoo', 'foobar'], $config->getReplace());
     }
 
     public function testReadsAndWritesTheLoadAfter(): void
@@ -62,9 +62,9 @@ class ConfigTest extends TestCase
 
         $this->assertEmpty($config->getLoadAfter());
 
-        $config->setLoadAfter(['foobar']);
+        $config->setLoadAfter(['foobar', 'barfoo']);
 
-        $this->assertSame(['foobar'], $config->getLoadAfter());
+        $this->assertSame(['barfoo', 'foobar'], $config->getLoadAfter());
     }
 
     public function testDisablesLoadingInProduction(): void

--- a/tests/Bundle/Parser/IniParserTest.php
+++ b/tests/Bundle/Parser/IniParserTest.php
@@ -56,7 +56,7 @@ class IniParserTest extends TestCase
 
         $this->assertSame('with-requires', $configs[0]->getName());
         $this->assertSame([], $configs[0]->getReplace());
-        $this->assertSame(['core', 'news', 'without-ini', 'calendar'], $configs[0]->getLoadAfter());
+        $this->assertSame(['calendar', 'core', 'news', 'without-ini'], $configs[0]->getLoadAfter());
         $this->assertTrue($configs[0]->loadInProduction());
         $this->assertTrue($configs[0]->loadInDevelopment());
     }


### PR DESCRIPTION
As discussed on Mumble on 2020-07-02, we want reproducible builds (as everyone else).
However, Contao creates a `bundles.map` which can vary per host, directory, etc. despite using the very same `composer.lock` for input.
This fixes that behaviour by sorting the loading order keys and therefore have an deterministic output of the resolved dependencies.