### PR TITLE
New interface to add http cache subscribers through a plugin

### DIFF
--- a/src/HttpKernel/HttpCacheSubscriberPluginInterface.php
+++ b/src/HttpKernel/HttpCacheSubscriberPluginInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin\HttpKernel;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+interface HttpCacheSubscriberPluginInterface
+{
+    /**
+     * Returns an array of event subscribers for the HTTP cache.
+     *
+     * @return array<EventSubscriberInterface>
+     */
+    public function getHttpCacheSubscribers(): array;
+}


### PR DESCRIPTION
This allows plugins to define HTTP cache subscribers. Requires https://github.com/contao/contao/pull/2148 for support in Contao.