### PR TITLE
Load legacy module ini files only once

### DIFF
--- a/src/Bundle/Config/ConfigResolver.php
+++ b/src/Bundle/Config/ConfigResolver.php
@@ -70,8 +70,8 @@ class ConfigResolver implements ConfigResolverInterface
 
         // If both are bundle configs, we have no problem and can merge
         return BundleConfig::create($otherConfig->getName())
-            ->setReplace(array_merge($otherConfig->getReplace(), $config->getReplace()))
-            ->setLoadAfter(array_merge($otherConfig->getLoadAfter(), $config->getLoadAfter()))
+            ->setReplace(array_unique(array_merge($otherConfig->getReplace(), $config->getReplace())))
+            ->setLoadAfter(array_unique(array_merge($otherConfig->getLoadAfter(), $config->getLoadAfter())))
             ->setLoadInProduction($otherConfig->loadInProduction() || $config->loadInProduction())
             ->setLoadInDevelopment($otherConfig->loadInDevelopment() || $config->loadInDevelopment())
         ;

--- a/src/Bundle/Parser/IniParser.php
+++ b/src/Bundle/Parser/IniParser.php
@@ -39,6 +39,7 @@ class IniParser implements ParserInterface
         if (isset($this->loaded[$resource])) {
             return [];
         }
+
         $configs = [];
         $config = new ModuleConfig($resource);
         $configs[] = $config;

--- a/src/Bundle/Parser/IniParser.php
+++ b/src/Bundle/Parser/IniParser.php
@@ -36,6 +36,9 @@ class IniParser implements ParserInterface
      */
     public function parse($resource, $type = null): array
     {
+        if (isset($this->loaded[$resource])) {
+            return [];
+        }
         $configs = [];
         $config = new ModuleConfig($resource);
         $configs[] = $config;

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -14,6 +14,7 @@ namespace Contao\ManagerPlugin\Tests\Bundle\Config;
 
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Config\ConfigResolver;
+use Contao\ManagerPlugin\Bundle\Config\ModuleConfig;
 use Contao\ManagerPlugin\Dependency\UnresolvableDependenciesException;
 use PHPUnit\Framework\TestCase;
 
@@ -108,8 +109,10 @@ class ConfigResolverTest extends TestCase
         $config7a = new BundleConfig('name7');
         $config7b = (new BundleConfig('name7'))->setReplace(['name2']);
         $config8a = (new BundleConfig('name8'))->setLoadAfter(['name1'])->setReplace(['foo']);
-        $config8b = (new BundleConfig('name8'))->setLoadAfter(['name2'])->setReplace(['bar']);
+        $config8b = (new BundleConfig('name8'))->setLoadAfter(['name1', 'name2'])->setReplace(['bar']);
         $config8c = (new BundleConfig('name8'))->setLoadAfter(['name1', 'name2'])->setReplace(['foo', 'bar']);
+        $config9a = new ModuleConfig('name9');
+        $config9b = new ModuleConfig('name9');
 
         return [
             'Test default configs' => [
@@ -182,6 +185,15 @@ class ConfigResolverTest extends TestCase
                     'name1' => $config1,
                     'name2' => $config2,
                     'name8' => $config8c,
+                ],
+            ],
+            'Test does not merge module configurations' => [
+                [
+                    $config9a,
+                    $config9b,
+                ],
+                [
+                    'name9' => $config9b,
                 ],
             ],
         ];

--- a/tests/Bundle/Parser/IniParserTest.php
+++ b/tests/Bundle/Parser/IniParserTest.php
@@ -74,6 +74,20 @@ class IniParserTest extends TestCase
         $this->assertSame(['recursion1'], $configs[1]->getLoadAfter());
     }
 
+    public function testParsesRecursiveRequiresOnlyOnce(): void
+    {
+        /** @var ConfigInterface[] $configs */
+        $configs = $this->parser->parse('recursion1');
+        $this->assertSame([], $this->parser->parse('recursion2'));
+
+        $this->assertCount(2, $configs);
+        $this->assertInstanceOf(ConfigInterface::class, $configs[0]);
+        $this->assertInstanceOf(ConfigInterface::class, $configs[1]);
+
+        $this->assertSame(['recursion2'], $configs[0]->getLoadAfter());
+        $this->assertSame(['recursion1'], $configs[1]->getLoadAfter());
+    }
+
     public function testParsesDirectoriesWithoutIniFile(): void
     {
         /** @var ConfigInterface[] $configs */


### PR DESCRIPTION
Fixes #30, replaces #32 

Before the legacy module ini files were loaded and returned multiple
times resulting in the config resolver trying to merge legacy configs
which naturally does not work (and should not have happened at all in
the first place).

Now the ini files are loaded only once and therefore not merged anymore.