### PR TITLE
Do not merge ModuleConfig objects

### DIFF
--- a/src/Bundle/Config/ModuleConfig.php
+++ b/src/Bundle/Config/ModuleConfig.php
@@ -15,6 +15,9 @@ namespace Contao\ManagerPlugin\Bundle\Config;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+/**
+ * @internal
+ */
 class ModuleConfig extends BundleConfig
 {
     public function __construct(string $name)

--- a/tests/Bundle/Config/ConfigResolverTest.php
+++ b/tests/Bundle/Config/ConfigResolverTest.php
@@ -61,6 +61,7 @@ class ConfigResolverTest extends TestCase
         $this->assertCount(\count($expectedResult), $actualResult);
 
         foreach ($expectedResult as $index => $config) {
+            $this->assertSame(\get_class($config), \get_class($actualResult[$index]));
             $this->assertSame($config->getName(), $actualResult[$index]->getName());
             $this->assertSame($config->getReplace(), $actualResult[$index]->getReplace());
             $this->assertSame($config->getLoadAfter(), $actualResult[$index]->getLoadAfter());
@@ -231,6 +232,18 @@ class ConfigResolverTest extends TestCase
         ;
 
         $this->expectException(UnresolvableDependenciesException::class);
+
+        $this->resolver->getBundleConfigs(false);
+    }
+
+    public function testFailsIfTheConfigsCannotBeMerged(): void
+    {
+        $this->resolver
+            ->add((new ModuleConfig('name1'))->setLoadAfter(['loadafter1']))
+            ->add((new ModuleConfig('name1'))->setLoadAfter(['loadafter2']))
+        ;
+
+        $this->expectException(\UnexpectedValueException::class);
 
         $this->resolver->getBundleConfigs(false);
     }


### PR DESCRIPTION
We discovered the strange error message `The Symfony bundle "multicolumnwizard" does not exist.`. This is because in https://github.com/terminal42/contao-leads/blob/0b60dc4b1d42d18bdfe4850008fe4fdc320b40d7/src/ContaoManager/Plugin.php#L37 the leads bundle creates a `ModuleConfig` instance (which we previously said is not a supported use case). Therefore two `ModuleConfig` instances exist and because `ModuleConfig` extends from `BundleConfig` the two `ModuleConfig`s are merged into one `BundleConfig`.

This is now fixed and tested with this PR. The error message now looks like `Unable to merge "haste" ("Contao\ManagerPlugin\Bundle\Config\ModuleConfig" with "Contao\ManagerPlugin\Bundle\Config\ModuleConfig").`

I also marked `ModuleConfig` as `@internal` to make it clear that this class should not be used by extensions.