### PR TITLE
Fix the PluginLoader effectively being immortal

### DIFF
--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -63,9 +63,10 @@ class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterfac
         $this->handleUpdateFromLegacyPlugin();
 
         $io = $event->getIO();
-
         $io->write('<info>contao/manager-plugin:</info> Dumping generated plugins file...');
+
         $this->doDumpPlugins($event->getComposer()->getRepositoryManager()->getLocalRepository(), $io);
+
         $io->write('<info>contao/manager-plugin:</info> ...done dumping generated plugins file');
     }
 
@@ -91,9 +92,9 @@ class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterfac
             return;
         }
 
-        // If the file did not exist at all or the content is not equal it means we're updating from an old version where
-        // the PluginLoader class got dynamically replaced. In that case we have to copy our file again and
-        // from that point in time on, things should work just fine.
+        // If the file did not exist at all or the content is not equal, it means we‘re updating from
+        // an old version where the PluginLoader class got dynamically replaced. In this case, we have
+        // to copy our file again and from that point in time on, things should work just fine.
         $fs->copy($resourcePath, $classPath, true);
     }
 

--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -60,21 +60,13 @@ class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterfac
 
     public function dumpPlugins(Event $event): void
     {
+        $this->handleUpdateFromLegacyPlugin();
+
         $io = $event->getIO();
 
-        if (!file_exists(__DIR__.'/../PluginLoader.php')) {
-            $io->write('<info>contao/manager-plugin:</info> Class not found (probably scheduled for removal); generation of plugin class skipped.');
-
-            return;
-        }
-
-        $io->write('<info>contao/manager-plugin:</info> Generating plugin class...');
-
-        // Require the autoload.php file so the Plugin classes are loaded
-        require $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
-
+        $io->write('<info>contao/manager-plugin:</info> Dumping generated plugins file...');
         $this->doDumpPlugins($event->getComposer()->getRepositoryManager()->getLocalRepository(), $io);
-        $io->write('<info>contao/manager-plugin:</info> ...done generating plugin class');
+        $io->write('<info>contao/manager-plugin:</info> ...done dumping generated plugins file');
     }
 
     /**
@@ -86,6 +78,23 @@ class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterfac
             ScriptEvents::POST_INSTALL_CMD => 'dumpPlugins',
             ScriptEvents::POST_UPDATE_CMD => 'dumpPlugins',
         ];
+    }
+
+    private function handleUpdateFromLegacyPlugin(): void
+    {
+        $fs = new Filesystem();
+        $classPath = __DIR__.'/../PluginLoader.php';
+        $resourcePath = __DIR__.'/../Resources/PluginLoader.php';
+
+        // In the old plugin version there were cases where the PluginLoader could not exist
+        if ($fs->exists($classPath) && file_get_contents($classPath) === file_get_contents($resourcePath)) {
+            return;
+        }
+
+        // If the file did not exist at all or the content is not equal it means we're updating from an old version where
+        // the PluginLoader class got dynamically replaced. In that case we have to copy our file again and
+        // from that point in time on, things should work just fine.
+        $fs->copy($resourcePath, $classPath, true);
     }
 
     private function doDumpPlugins(RepositoryInterface $repository, IOInterface $io): void

--- a/src/Resources/PluginLoader.php
+++ b/src/Resources/PluginLoader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin;
+
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Config\ConfigPluginInterface;
+use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
+use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
+
+class PluginLoader
+{
+    public const BUNDLE_PLUGINS = BundlePluginInterface::class;
+    public const CONFIG_PLUGINS = ConfigPluginInterface::class;
+    public const EXTENSION_PLUGINS = ExtensionPluginInterface::class;
+    public const ROUTING_PLUGINS = RoutingPluginInterface::class;
+
+    /**
+     * @var array
+     */
+    private $plugins = [];
+
+    /**
+     * @var array
+     */
+    private $disabled = [];
+
+    public function __construct(string $installedJson = null, array $plugins = null)
+    {
+        if (null !== $installedJson) {
+            @trigger_error('Passing the path to the Composer installed.json as first argument is no longer supported in version 2.3.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $plugins) {
+            $this->plugins = $plugins;
+        } elseif (is_file(self::getGeneratedPath())) {
+            $this->plugins = (array) include self::getGeneratedPath();
+        }
+    }
+
+    public static function getGeneratedPath(): string
+    {
+        return __DIR__.'/../.generated/plugins.php';
+    }
+
+    /**
+     * Returns all active plugin instances.
+     *
+     * @return array<string,BundlePluginInterface>
+     */
+    public function getInstances(): array
+    {
+        return array_diff_key($this->plugins, array_flip($this->disabled));
+    }
+
+    /**
+     * Returns the active plugin instances of a given type (see class constants).
+     *
+     * @return array<string,BundlePluginInterface>
+     */
+    public function getInstancesOf(string $type, bool $reverseOrder = false): array
+    {
+        $plugins = array_filter(
+            $this->getInstances(),
+            static function ($plugin) use ($type) {
+                return is_a($plugin, $type);
+            }
+        );
+
+        if ($reverseOrder) {
+            $plugins = array_reverse($plugins, true);
+        }
+
+        return array_diff_key($plugins, array_flip($this->disabled));
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getDisabledPackages(): array
+    {
+        return $this->disabled;
+    }
+
+    public function setDisabledPackages(array $packages): void
+    {
+        $this->disabled = $packages;
+    }
+}

--- a/tests/Composer/ManagerPluginInstallerTest.php
+++ b/tests/Composer/ManagerPluginInstallerTest.php
@@ -51,40 +51,6 @@ class ManagerPluginInstallerTest extends TestCase
         (new ManagerPluginInstaller())->activate($composer, $io);
     }
 
-    public function testLoadsAutoloadFileFromVendor(): void
-    {
-        $config = $this->createMock(Config::class);
-        $config
-            ->expects($this->once())
-            ->method('get')
-            ->with('vendor-dir')
-            ->willReturn(__DIR__.'/../Fixtures/Composer/test-vendor')
-        ;
-
-        $composer = $this->createMock(Composer::class);
-        $composer
-            ->expects($this->once())
-            ->method('getConfig')
-            ->willReturn($config)
-        ;
-
-        $event = $this->createMock(Event::class);
-        $event
-            ->method('getComposer')
-            ->willReturn($composer)
-        ;
-
-        $event
-            ->method('getIO')
-            ->willReturn($this->createMock(IOInterface::class))
-        ;
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('autoload.php successfully loaded');
-
-        (new ManagerPluginInstaller())->dumpPlugins($event);
-    }
-
     public function testSubscribesToInstallAndUpdateEvent(): void
     {
         $events = ManagerPluginInstaller::getSubscribedEvents();
@@ -121,11 +87,11 @@ class ManagerPluginInstallerTest extends TestCase
             ->expects($this->exactly(5))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE],
                 [' - Added plugin for foo/config-bundle', true, IOInterface::VERY_VERBOSE],
                 [' - Added plugin for foo/console-bundle', true, IOInterface::VERY_VERBOSE],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -154,8 +120,8 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -284,9 +250,9 @@ return array (
             ->expects($this->exactly(3))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/config-bundle', true, IOInterface::VERY_VERBOSE],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -345,7 +311,7 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE]
             )
         ;
@@ -378,7 +344,7 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE]
             )
         ;

--- a/tests/PluginLoaderTest.php
+++ b/tests/PluginLoaderTest.php
@@ -88,4 +88,9 @@ class PluginLoaderTest extends TestCase
         $this->assertSame('foo/config2-bundle', $keys[1]);
         $this->assertSame('foo/config1-bundle', $keys[2]);
     }
+
+    public function testLegacyUpdateFilesAreIdentical(): void
+    {
+        $this->assertFileEquals(__DIR__.'/../src/PluginLoader.php', __DIR__.'/../src/Resources/PluginLoader.php');
+    }
 }


### PR DESCRIPTION
This fixes updating from 2.11.* or < 2.11 to the main branch. It also shows why it's so important we changed the fact that we replace the `PluginLoader` on every update because it was effectively immortal. When you run `composer update` or `composer install` the plugins are loaded into the process memory so what will happen is that it will always dump the previous version which might cause a lot of trouble. This is fixed now that we do not replace the `PluginLoader` anymore but use a separate, generated file but this PR is required to fix the update from previous versions to the latest one.