### PR TITLE
Fix the PluginLoader effectively being immortal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # PhpUnit
 /phpunit.xml
 /.phpunit.result.cache
+
+# Generated files
+/.generated

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,9 @@
             "bin-links": false,
             "target-directory": "tools"
         },
+        "branch-alias": {
+            "dev-main": "2.12.x-dev"
+        },
         "class": [
             "Contao\\ManagerPlugin\\Composer\\ArtifactsPlugin",
             "Contao\\ManagerPlugin\\Composer\\ManagerPluginInstaller",

--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -23,113 +23,12 @@ use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Contao\ManagerPlugin\Dependency\DependencyResolverTrait;
 use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
+use Contao\ManagerPlugin\PluginLoader;
 use Symfony\Component\Filesystem\Filesystem;
 
 class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterface
 {
     use DependencyResolverTrait;
-
-    /**
-     * @var string
-     */
-    private static $generatedClassTemplate = <<<'PHP'
-<?php
-
-declare(strict_types=1);
-
-/*
- * This file is part of Contao.
- *
- * (c) Leo Feyer
- *
- * @license LGPL-3.0-or-later
- */
-
-namespace Contao\ManagerPlugin;
-
-use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
-use Contao\ManagerPlugin\Config\ConfigPluginInterface;
-use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
-use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
-
-/**
- * This class has been auto-generated. It will be overwritten at every run of
- * "composer install" or "composer update".
- *
- * @see \Contao\ManagerPlugin\Composer\Installer
- */
-%s
-{
-    public const BUNDLE_PLUGINS = BundlePluginInterface::class;
-    public const CONFIG_PLUGINS = ConfigPluginInterface::class;
-    public const EXTENSION_PLUGINS = ExtensionPluginInterface::class;
-    public const ROUTING_PLUGINS = RoutingPluginInterface::class;
-
-    /**
-     * @var array
-     */
-    private $plugins;
-
-    /**
-     * @var array
-     */
-    private $disabled = [];
-
-    public function __construct(string $installedJson = null, array $plugins = null)
-    {
-        if (null !== $installedJson) {
-            @trigger_error('Passing the path to the Composer installed.json as first argument is no longer supported in version 2.3.', E_USER_DEPRECATED);
-        }
-
-        $this->plugins = $plugins ?: %s;
-    }
-
-    /**
-     * Returns all active plugin instances.
-     *
-     * @return array<string,BundlePluginInterface>
-     */
-    public function getInstances(): array
-    {
-        return array_diff_key($this->plugins, array_flip($this->disabled));
-    }
-
-    /**
-     * Returns the active plugin instances of a given type (see class constants).
-     *
-     * @return array<string,BundlePluginInterface>
-     */
-    public function getInstancesOf(string $type, bool $reverseOrder = false): array
-    {
-        $plugins = array_filter(
-            $this->getInstances(),
-            function ($plugin) use ($type) {
-                return is_a($plugin, $type);
-            }
-        );
-
-        if ($reverseOrder) {
-            $plugins = array_reverse($plugins, true);
-        }
-
-        return array_diff_key($plugins, array_flip($this->disabled));
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getDisabledPackages(): array
-    {
-        return $this->disabled;
-    }
-
-    public function setDisabledPackages(array $packages): void
-    {
-        $this->disabled = $packages;
-    }
-}
-
-PHP;
 
     /**
      * @var Filesystem
@@ -231,23 +130,15 @@ PHP;
 
         foreach ($plugins as $package => $plugin) {
             $class = \get_class($plugin);
-            $load[] = "            '$package' => new \\$class()";
-        }
-
-        // Dump empty list if there are no packages
-        if (empty($load)) {
-            $pluginList = '[]';
-        } else {
-            $pluginList = sprintf("[\n%s,\n        ]", implode(",\n", $load));
+            $load[$package] = "#new \\$class()#";
         }
 
         $content = sprintf(
-            static::$generatedClassTemplate,
-            'cla'.'ss '.'PluginLoader', // workaround for regex-based code parsers :-(
-            $pluginList
+            "<?php\nreturn %s;",
+            str_replace(['\'#', '#\'', '\\\\'], ['', '', '\\'], var_export($load, true))
         );
 
-        $this->filesystem->dumpFile(__DIR__.'/../PluginLoader.php', $content);
+        $this->filesystem->dumpFile(PluginLoader::getGeneratedPath(), $content);
     }
 
     /**

--- a/src/Composer/ManagerPluginInstaller.php
+++ b/src/Composer/ManagerPluginInstaller.php
@@ -65,6 +65,9 @@ class ManagerPluginInstaller implements PluginInterface, EventSubscriberInterfac
         $io = $event->getIO();
         $io->write('<info>contao/manager-plugin:</info> Dumping generated plugins file...');
 
+        // Require the autoload.php file so the Plugin classes are loaded
+        require $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
+
         $this->doDumpPlugins($event->getComposer()->getRepositoryManager()->getLocalRepository(), $io);
 
         $io->write('<info>contao/manager-plugin:</info> ...done dumping generated plugins file');

--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -17,10 +17,6 @@ use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 
-/**
- * This is a stub class which will be replaced during "composer install" or
- * "composer update" unless Composer is run with the "--no-scripts" flag.
- */
 class PluginLoader
 {
     public const BUNDLE_PLUGINS = BundlePluginInterface::class;
@@ -31,7 +27,7 @@ class PluginLoader
     /**
      * @var array
      */
-    private $plugins;
+    private $plugins = [];
 
     /**
      * @var array
@@ -44,7 +40,16 @@ class PluginLoader
             @trigger_error('Passing the path to the Composer installed.json as first argument is no longer supported in version 2.3.', E_USER_DEPRECATED);
         }
 
-        $this->plugins = $plugins ?: [];
+        if (null !== $plugins) {
+            $this->plugins = $plugins;
+        } elseif (is_file(self::getGeneratedPath())) {
+            $this->plugins = (array) include self::getGeneratedPath();
+        }
+    }
+
+    public static function getGeneratedPath(): string
+    {
+        return __DIR__.'/../.generated/plugins.php';
     }
 
     /**

--- a/src/Resources/PluginLoader.php
+++ b/src/Resources/PluginLoader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerPlugin;
+
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Config\ConfigPluginInterface;
+use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
+use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
+
+class PluginLoader
+{
+    public const BUNDLE_PLUGINS = BundlePluginInterface::class;
+    public const CONFIG_PLUGINS = ConfigPluginInterface::class;
+    public const EXTENSION_PLUGINS = ExtensionPluginInterface::class;
+    public const ROUTING_PLUGINS = RoutingPluginInterface::class;
+
+    /**
+     * @var array
+     */
+    private $plugins = [];
+
+    /**
+     * @var array
+     */
+    private $disabled = [];
+
+    public function __construct(string $installedJson = null, array $plugins = null)
+    {
+        if (null !== $installedJson) {
+            @trigger_error('Passing the path to the Composer installed.json as first argument is no longer supported in version 2.3.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $plugins) {
+            $this->plugins = $plugins;
+        } elseif (is_file(self::getGeneratedPath())) {
+            $this->plugins = (array) include self::getGeneratedPath();
+        }
+    }
+
+    public static function getGeneratedPath(): string
+    {
+        return __DIR__.'/../.generated/plugins.php';
+    }
+
+    /**
+     * Returns all active plugin instances.
+     *
+     * @return array<string,BundlePluginInterface>
+     */
+    public function getInstances(): array
+    {
+        return array_diff_key($this->plugins, array_flip($this->disabled));
+    }
+
+    /**
+     * Returns the active plugin instances of a given type (see class constants).
+     *
+     * @return array<string,BundlePluginInterface>
+     */
+    public function getInstancesOf(string $type, bool $reverseOrder = false): array
+    {
+        $plugins = array_filter(
+            $this->getInstances(),
+            static function ($plugin) use ($type) {
+                return is_a($plugin, $type);
+            }
+        );
+
+        if ($reverseOrder) {
+            $plugins = array_reverse($plugins, true);
+        }
+
+        return array_diff_key($plugins, array_flip($this->disabled));
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getDisabledPackages(): array
+    {
+        return $this->disabled;
+    }
+
+    public function setDisabledPackages(array $packages): void
+    {
+        $this->disabled = $packages;
+    }
+}

--- a/tests/Composer/ManagerPluginInstallerTest.php
+++ b/tests/Composer/ManagerPluginInstallerTest.php
@@ -51,40 +51,6 @@ class ManagerPluginInstallerTest extends TestCase
         (new ManagerPluginInstaller())->activate($composer, $io);
     }
 
-    public function testLoadsAutoloadFileFromVendor(): void
-    {
-        $config = $this->createMock(Config::class);
-        $config
-            ->expects($this->once())
-            ->method('get')
-            ->with('vendor-dir')
-            ->willReturn(__DIR__.'/../Fixtures/Composer/test-vendor')
-        ;
-
-        $composer = $this->createMock(Composer::class);
-        $composer
-            ->expects($this->once())
-            ->method('getConfig')
-            ->willReturn($config)
-        ;
-
-        $event = $this->createMock(Event::class);
-        $event
-            ->method('getComposer')
-            ->willReturn($composer)
-        ;
-
-        $event
-            ->method('getIO')
-            ->willReturn($this->createMock(IOInterface::class))
-        ;
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('autoload.php successfully loaded');
-
-        (new ManagerPluginInstaller())->dumpPlugins($event);
-    }
-
     public function testSubscribesToInstallAndUpdateEvent(): void
     {
         $events = ManagerPluginInstaller::getSubscribedEvents();
@@ -121,11 +87,11 @@ class ManagerPluginInstallerTest extends TestCase
             ->expects($this->exactly(5))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE],
                 [' - Added plugin for foo/config-bundle', true, IOInterface::VERY_VERBOSE],
                 [' - Added plugin for foo/console-bundle', true, IOInterface::VERY_VERBOSE],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -154,8 +120,8 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -284,9 +250,9 @@ return array (
             ->expects($this->exactly(3))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/config-bundle', true, IOInterface::VERY_VERBOSE],
-                ['<info>contao/manager-plugin:</info> ...done generating plugin class']
+                ['<info>contao/manager-plugin:</info> ...done dumping generated plugins file']
             )
         ;
 
@@ -345,7 +311,7 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE]
             )
         ;
@@ -378,7 +344,7 @@ return array (
             ->expects($this->exactly(2))
             ->method('write')
             ->withConsecutive(
-                ['<info>contao/manager-plugin:</info> Generating plugin class...'],
+                ['<info>contao/manager-plugin:</info> Dumping generated plugins file...'],
                 [' - Added plugin for foo/bar-bundle', true, IOInterface::VERY_VERBOSE]
             )
         ;

--- a/tests/Composer/ManagerPluginInstallerTest.php
+++ b/tests/Composer/ManagerPluginInstallerTest.php
@@ -129,12 +129,12 @@ class ManagerPluginInstallerTest extends TestCase
             )
         ;
 
-        $filesystem = $this->mockFilesystemAndCheckDump("
-        \$this->plugins = \$plugins ?: [
-            'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
-            'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
-            'foo/console-bundle' => new \\Foo\\Console\\FooConsolePlugin(),
-        ];");
+        $filesystem = $this->mockFilesystemAndCheckDump("<?php
+return array (
+  'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
+  'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
+  'foo/console-bundle' => new \\Foo\\Console\\FooConsolePlugin(),
+);");
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -159,8 +159,9 @@ class ManagerPluginInstallerTest extends TestCase
             )
         ;
 
-        $filesystem = $this->mockFilesystemAndCheckDump('
-        $this->plugins = $plugins ?: [];');
+        $filesystem = $this->mockFilesystemAndCheckDump('<?php
+return array (
+);');
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -183,11 +184,11 @@ class ManagerPluginInstallerTest extends TestCase
 
         $io = $this->createMock(IOInterface::class);
 
-        $filesystem = $this->mockFilesystemAndCheckDump("
-        \$this->plugins = \$plugins ?: [
-            'contao/manager-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
-            'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
-        ];");
+        $filesystem = $this->mockFilesystemAndCheckDump("<?php
+return array (
+  'contao/manager-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
+  'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
+);");
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -218,11 +219,11 @@ class ManagerPluginInstallerTest extends TestCase
 
         $io = $this->createMock(IOInterface::class);
 
-        $filesystem = $this->mockFilesystemAndCheckDump("
-        \$this->plugins = \$plugins ?: [
-            'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
-            'app' => new \\ContaoManagerPlugin(),
-        ];");
+        $filesystem = $this->mockFilesystemAndCheckDump("<?php
+return array (
+  'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
+  'app' => new \\ContaoManagerPlugin(),
+);");
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -253,11 +254,11 @@ class ManagerPluginInstallerTest extends TestCase
 
         $io = $this->createMock(IOInterface::class);
 
-        $filesystem = $this->mockFilesystemAndCheckDump("
-        \$this->plugins = \$plugins ?: [
-            'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
-            'app' => new \\App\\ContaoManager\\Plugin(),
-        ];");
+        $filesystem = $this->mockFilesystemAndCheckDump("<?php
+return array (
+  'foo/bar-bundle' => new \\Foo\\Bar\\FooBarPlugin(),
+  'app' => new \\App\\ContaoManager\\Plugin(),
+);");
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -289,10 +290,10 @@ class ManagerPluginInstallerTest extends TestCase
             )
         ;
 
-        $filesystem = $this->mockFilesystemAndCheckDump("
-        \$this->plugins = \$plugins ?: [
-            'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
-        ];");
+        $filesystem = $this->mockFilesystemAndCheckDump("<?php
+return array (
+  'foo/config-bundle' => new \\Foo\\Config\\FooConfigPlugin(),
+);");
 
         $installer = new ManagerPluginInstaller($filesystem);
         $installer->dumpPlugins($this->mockEventWithRepositoryAndIO($repository, $io));
@@ -458,7 +459,7 @@ class ManagerPluginInstallerTest extends TestCase
             ->expects($this->once())
             ->method('dumpFile')
             ->with(
-                \dirname(__DIR__, 2).'/src/Composer/../PluginLoader.php',
+                \dirname(__DIR__, 2).'/src/../.generated/plugins.php',
                 $this->callback(
                     static function ($content) use ($match) {
                         return false !== strpos($content, $match);

--- a/tests/PluginLoaderTest.php
+++ b/tests/PluginLoaderTest.php
@@ -24,7 +24,7 @@ class PluginLoaderTest extends TestCase
 {
     public function testCanBeInstantiated(): void
     {
-        $pluginLoader = new PluginLoader();
+        $pluginLoader = new PluginLoader(null, []);
 
         $this->assertInstanceOf('Contao\ManagerPlugin\PluginLoader', $pluginLoader);
     }

--- a/tests/PluginLoaderTest.php
+++ b/tests/PluginLoaderTest.php
@@ -88,4 +88,9 @@ class PluginLoaderTest extends TestCase
         $this->assertSame('foo/config2-bundle', $keys[1]);
         $this->assertSame('foo/config1-bundle', $keys[2]);
     }
+
+    public function testLegacyUpdateFilesAreIdentical(): void
+    {
+        $this->assertFileEquals(__DIR__.'/../src/PluginLoader.php', __DIR__.'/../src/Resources/PluginLoader.php');
+    }
 }


### PR DESCRIPTION
Unfortunately, there is still a problem with the changes. I have required `contao/manager-plugin` in version `2.12.x-dev`. After trying to install the dependencies of the calendar bundle, the following error occurred:

<img width="740" alt="" src="https://user-images.githubusercontent.com/1192057/180208111-4d21de09-df53-441e-8d7d-0c2d69912f18.png">
