### PR TITLE
Add provider repositories on require command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "composer-plugin-api": "^1.1 || ^2.0",
+        "composer-plugin-api": "^1.7 || ^2.0",
         "symfony/config": "^3.3 || ^4.0 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^3.3 || ^4.0 || ^5.0 || ^6.0",
         "symfony/filesystem": "^3.3 || ^4.0 || ^5.0 || ^6.0",
@@ -21,7 +21,7 @@
     "require-dev": {
         "ext-zip": "*",
         "bamarni/composer-bin-plugin": "^1.4",
-        "composer/composer": "^1.1 || ^2.0",
+        "composer/composer": "^1.7 || ^2.0",
         "contao/core-bundle": "^4.4 || ^5.0",
         "php-http/guzzle6-adapter": "^1.1",
         "phpunit/phpunit": "^8.5 || ^9.3",

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -17,12 +17,12 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
+use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PreCommandRunEvent;
 use Composer\Repository\ArtifactRepository;
 use Composer\Repository\RepositoryInterface;
-use Composer\Package\Version\VersionParser;
 
 class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
 {
@@ -57,6 +57,7 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
         }
 
         $requires = [];
+
         foreach ($composer->getPackage()->getRequires() as $name => $link) {
             $requires[$name] = $link->getConstraint();
         }
@@ -84,6 +85,7 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
         $requirements = $versionParser->parseNameVersionPairs($event->getInput()->getArgument('packages'));
 
         $requires = [];
+
         foreach ($requirements as $requirement) {
             $requires[$requirement['name']] = $versionParser->parseConstraints($requirement['version'] ?? '*');
         }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -88,7 +88,6 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
             $requires[$requirement['name']] = $versionParser->parseConstraints($requirement['version'] ?? '*');
         }
 
-        // Ping
         if ([] === $requires) {
             return;
         }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -88,6 +88,7 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
             $requires[$requirement['name']] = $versionParser->parseConstraints($requirement['version'] ?? '*');
         }
 
+        // Ping
         if ([] === $requires) {
             return;
         }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -95,6 +95,13 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
         $this->registerProviders($requires);
     }
 
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PluginEvents::PRE_COMMAND_RUN => ['preCommandRun', 1],
+        ];
+    }
+
     private function addArtifactRepository(Composer $composer, string $repositoryUrl): ?RepositoryInterface
     {
         $repository = $composer->getRepositoryManager()->createRepository('artifact', ['url' => $repositoryUrl]);
@@ -214,12 +221,5 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
         }
 
         return $indexOfShortestMatch;
-    }
-
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            PluginEvents::PRE_COMMAND_RUN => ['preCommandRun', 1],
-        ];
     }
 }

--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -22,7 +22,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PreCommandRunEvent;
 use Composer\Repository\ArtifactRepository;
 use Composer\Repository\RepositoryInterface;
-use Composer\Semver\VersionParser;
+use Composer\Package\Version\VersionParser;
 
 class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
 {
@@ -80,10 +80,9 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $packages = $event->getInput()->getArgument('packages');
-        $requirements = (new \Composer\Package\Version\VersionParser())->parseNameVersionPairs($packages);
-
         $versionParser = new VersionParser();
+        $requirements = $versionParser->parseNameVersionPairs($event->getInput()->getArgument('packages'));
+
         $requires = [];
         foreach ($requirements as $requirement) {
             $requires[$requirement['name']] = $versionParser->parseConstraints($requirement['version'] ?? '*');

--- a/tests/Composer/ArtifactsPluginTest.php
+++ b/tests/Composer/ArtifactsPluginTest.php
@@ -522,7 +522,7 @@ class ArtifactsPluginTest extends TestCase
                     '1.0.0',
                     __DIR__.'/../Fixtures/Composer/provider-data/contao-manager/packages/foo-bar-1.0.0.zip'
                 ),
-            ],
+            ]
         );
 
         /** @var PackageInterface|MockObject $rootPackage */

--- a/tests/Composer/ArtifactsPluginTest.php
+++ b/tests/Composer/ArtifactsPluginTest.php
@@ -492,7 +492,6 @@ class ArtifactsPluginTest extends TestCase
         ];
 
         $config = $this->mockConfig(null);
-
         $config
             ->expects($this->exactly(2))
             ->method('merge')


### PR DESCRIPTION
Our Composer plugin dynamically registers repository URLs for packages in the artifact repository `/contao-manager/packages`. Currently, it only adds repositories for packages that are required (= are listed in the root `composer.json`). 

This pull request extends the capability to also register repository URLs in the `composer require` command. This fixes the problem that you cannot require a `contao-provider` and a package provided by that provider at the same time.