### PR TITLE
Automatically skip broken symlinks in system/modules

### DIFF
--- a/src/Bundle/Parser/IniParser.php
+++ b/src/Bundle/Parser/IniParser.php
@@ -36,7 +36,7 @@ class IniParser implements ParserInterface
      */
     public function parse($resource, $type = null): array
     {
-        if (isset($this->loaded[$resource])) {
+        if (isset($this->loaded[$resource]) || !is_dir($this->modulesDir.'/'.$resource)) {
             return [];
         }
 


### PR DESCRIPTION
If there is a symlink in `system/modules` to a `vedor/...` folder that no longer exists, the plugin currently tries to create a `ModuleBundle` for it, which fails because the source cannot be found. I think we can safely skip broken symlinks when loading modules.

Maybe @fritzmg can manually test if this also works on Windows? I manually created three folders in `system/modules`, a regular one, a working symlink and a broken symlink, and `is_dir` "correctly" returned `false` on the broken symlink. I hope Windows does that too? 😅 