### PR TITLE
Correctly prepend new repositories so they win over packagist.org

### DIFF
--- a/src/Composer/ArtifactsPlugin.php
+++ b/src/Composer/ArtifactsPlugin.php
@@ -112,7 +112,7 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
             return null;
         }
 
-        $composer->getRepositoryManager()->addRepository($repository);
+        $composer->getRepositoryManager()->prependRepository($repository);
         $composer->getConfig()->merge(['repositories' => [['type' => 'artifact', 'url' => $repositoryUrl]]]);
 
         return $repository;
@@ -151,7 +151,7 @@ class ArtifactsPlugin implements PluginInterface, EventSubscriberInterface
         if (!empty($repositories)) {
             foreach ($repositories as $config) {
                 $repo = $repositoryManager->createRepository($config['type'], $config);
-                $repositoryManager->addRepository($repo);
+                $repositoryManager->prependRepository($repo);
             }
 
             $this->composer->getConfig()->merge(['repositories' => array_values($repositories)]);

--- a/tests/Composer/ArtifactsPluginTest.php
+++ b/tests/Composer/ArtifactsPluginTest.php
@@ -55,7 +55,7 @@ class ArtifactsPluginTest extends TestCase
 
         $repositoryManager
             ->expects($this->once())
-            ->method('addRepository')
+            ->method('prependRepository')
             ->with($repository)
         ;
 
@@ -99,7 +99,7 @@ class ArtifactsPluginTest extends TestCase
 
         $repositoryManager
             ->expects($this->once())
-            ->method('addRepository')
+            ->method('prependRepository')
             ->with($repository)
         ;
 
@@ -133,7 +133,7 @@ class ArtifactsPluginTest extends TestCase
 
         $repositoryManager
             ->expects($this->never())
-            ->method('addRepository')
+            ->method('prependRepository')
         ;
 
         putenv('COMPOSER='.__DIR__.'/../Fixtures/Composer/null-data/composer.json');
@@ -168,7 +168,7 @@ class ArtifactsPluginTest extends TestCase
 
         $repositoryManager
             ->expects($this->never())
-            ->method('addRepository')
+            ->method('prependRepository')
         ;
 
         putenv('COMPOSER='.__DIR__.'/../Fixtures/Composer/artifact-data/composer.json');
@@ -381,7 +381,7 @@ class ArtifactsPluginTest extends TestCase
 
         $repositoryManager
             ->expects($this->exactly(2))
-            ->method('addRepository')
+            ->method('prependRepository')
         ;
 
         $plugin = new ArtifactsPlugin();


### PR DESCRIPTION
The `manager-plugin` automatically adds an artifact repository to the Contao installation, if `contao-manager/packages` exists in the project root. It add the repository to the repository manager as well as the composer configuration (same as if it was added to the `composer.json`).

When merging repository configuration, the merged configuration wins over the existing one, meaning new repositories are prepended to the existing ones to take priority. That is not the case for the repository manager though. In this case, it means the packagist.org repository would win over the local artifacts, which is wrong (and not the case with configs).